### PR TITLE
Add `make shell` command to run a pshell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ lti/static/pdfjs/viewer/web/*.pdf
 .tox
 .cache
 *.pyc
+*.egg-info

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ clean:
 
 .PHONY: dev
 dev: .pydeps
-	@PYRAMID_RELOAD_TEMPLATES=1 gunicorn --reload --bind 'localhost:8001' 'lti.app:app()'
+	gunicorn --paste conf/development.ini
+
+.PHONY: shell
+shell: .pydeps
+	pshell conf/development.ini
 
 .PHONY: test
 test:
@@ -28,7 +32,7 @@ lint:
 	@pip install -q tox
 	tox -e lint
 
-.pydeps: requirements.txt
+.pydeps: requirements.txt requirements-dev.in
 	@echo installing python dependencies
 	@pip install --use-wheel -r requirements-dev.in
 	@touch $@

--- a/README.markdown
+++ b/README.markdown
@@ -121,6 +121,24 @@ To get the Canvas app running in a dev environment:
 $ make test
 ```
 
+### Getting a shell
+
+`make shell` will get you a Python shell with a Pyramid registry, request, etc.
+Useful for debugging or trying things out in development:
+
+```bash
+$ make shell
+```
+
+**Tip**: If you install `pyramid_ipython` then `make shell` will give you an
+IPython shell instead of a plain Python one:
+
+```
+$ pip install pyramid_ipython
+```
+
+There are also `pyramid_` packages for `bpython`, `ptpython`, etc.
+
 ### Running the linters
 
 ```bash

--- a/conf/development.ini
+++ b/conf/development.ini
@@ -1,0 +1,52 @@
+[app:main]
+use = call:lti.app:create_app
+
+pyramid.reload_templates = true
+pyramid.debug_authorization = false
+pyramid.debug_notfound = false
+pyramid.debug_routematch = false
+pyramid.default_locale_name = en
+pyramid.includes =
+    pyramid_debugtoolbar
+
+# By default, the toolbar only appears for clients from IP addresses
+# '127.0.0.1' and '::1'.
+# debugtoolbar.hosts = 127.0.0.1 ::1
+
+[server:main]
+use: egg:gunicorn
+host: 0.0.0.0
+port: 8001
+reload: true
+
+###
+# logging configuration
+# https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
+###
+
+[loggers]
+keys = root, lti
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_lti]
+level = DEBUG
+handlers =
+qualname = lti
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s

--- a/lti/app.py
+++ b/lti/app.py
@@ -547,8 +547,8 @@ def lti_serve_pdf(request):
 from pyramid.response import Response
 from pyramid.static import static_view
 
-def app():
-    config = configure()
+def create_app(global_config, **settings):  # pylint: disable=unused-argument
+    config = configure(settings=settings)
 
     config.include('pyramid_jinja2')
 

--- a/lti/config/__init__.py
+++ b/lti/config/__init__.py
@@ -12,12 +12,19 @@ from lti.config.settings import (
 )
 
 
-def configure():
+def configure(settings=None):
     """Return a Configurator for the Pyramid application."""
-    return Configurator(settings={
-        'lti_server': env_setting('LTI_SERVER'),
-        'lti_credentials_url': env_setting('LTI_CREDENTIALS_URL'),
-    })
+    if settings is None:
+        settings = {}
+
+    # Settings from the config file are extended / overwritten by settings from
+    # the environment.
+    settings.update(dict(
+        lti_server=env_setting('LTI_SERVER'),
+        lti_credentials_url=env_setting('LTI_CREDENTIALS_URL'),
+    ))
+
+    return Configurator(settings=settings)
 
 
 __all__ = (

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,5 @@
 -r requirements.txt
+-e .
 
 pip-tools
+pyramid_debugtoolbar

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+import os
+
+from setuptools import setup, find_packages
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(HERE, 'README.markdown')) as f:
+    README = f.read()
+
+setup(
+    name='lti',
+    description='Hypothesis Canvas app',
+    long_description=README,
+    classifiers=[
+        'Programming Language :: Python',
+        'Framework :: Pyramid',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Internet :: WWW/HTTP :: WSGI :: Application',
+    ],
+    url='https://github.com/hypothesis/lti',
+    keywords='web pyramid pylons',
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
+)


### PR DESCRIPTION
Make [pshell](https://docs.pylonsproject.org/projects/pyramid/en/latest/pscripts/pshell.html?highlight=pshell) work with the `lti` package: add a `setup.py` file so that the `lti` app becomes an installable Python package and add a `development.ini` file so that it becomes compatible with PasteDeploy. Both of these seem to be required by pshell.

Both h and bouncer are _not_ installable Python packages - they don't have `setup.py` files. Bouncer doesn't have a PasteDeploy config file either (no `development.ini` file).

I'm not sure what the motivation for not having `setup.py` files is. Probably they're not needed with the way that we deploy these apps in production. But leaving them out also means that pshell doesn't work with the apps in development.

h actually has its own `hypothesis` command that can be used to get a development shell among other things, but I don't think I want to go so far as to implement a whole custom command line interface for the lti app.

With bouncer it's just not possible to get a development shell, as far as I know.

This pull requests adds a development shell for the lti app, accessible via `make shell`, by adding `setup.p` and `development.in` to make the app compatible with `pshell`:

In order to get `pshell` working it was necessary to:

1. Make `lti` an installable Python package so that `pshell` can find it.

   Add a `setup.py` file so that the `lti` Python package can be installed in a local development environment by doing `pip install -e .`

2. Add a `conf/development.ini` file (PasteDeploy config file) so that the `lti` app can be run via PasteDeploy, because `pshell` requires this.

   I also changed `make dev` to run the app via PasteDeploy, just for consistency.

   I changed `lti.app` to load configuration settings from the config file first, and then config settings from environment variables extend and override the config file. Previously it was loading settings from env vars only. This enables the `development.ini` file to contain some default dev settings.