### PR TITLE
Extract Pyramid routes into separate file

### DIFF
--- a/lti/app.py
+++ b/lti/app.py
@@ -542,27 +542,12 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config = configure(settings=settings)
 
     config.include('pyramid_jinja2')
-
-    config.scan()
-
+    config.include('lti.routes')
     config.include('lti.models')
 
-    config.add_route('token_callback',      '/token_callback')
-    config.add_route('refresh_callback',    '/refresh_callback')
-    config.add_route('lti_setup',           '/lti_setup')
-    config.add_route('lti_submit',          '/lti_submit')
-    config.add_route('lti_export',          '/lti_export')
-    config.add_route('lti_credentials',     '/lti_credentials')
-    config.add_route('config_xml',          '/config')  # FIXME: This should be /config.xml as in Canvas's examples.
-    config.add_route('about',               '/')
-
-    config.add_route('lti_serve_pdf',       '/viewer/web/{file}.pdf')
-
     pdf_view = static_view('lti:static/pdfjs')
-    config.add_route('catchall_pdf', '/viewer/*subpath')
     config.add_view(pdf_view, route_name='catchall_pdf')
-
-
     config.add_static_view(name='export', path='lti:static/export')
 
+    config.scan()
     return config.make_wsgi_app()

--- a/lti/routes.py
+++ b/lti/routes.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+
+def includeme(config):
+    config.add_route('about', '/')
+
+    config.add_route('token_callback', '/token_callback')
+    config.add_route('refresh_callback', '/refresh_callback')
+
+    config.add_route('config_xml', '/config.xml')
+
+    config.add_route('lti_credentials', '/lti_credentials')
+    config.add_route('lti_setup', '/lti_setup')
+    config.add_route('lti_submit', '/lti_submit')
+    config.add_route('lti_export', '/lti_export')
+
+    config.add_route('lti_serve_pdf', '/viewer/web/{file}.pdf')
+    config.add_route('catchall_pdf', '/viewer/*subpath')

--- a/tests/lti/test_routes.py
+++ b/tests/lti/test_routes.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from lti.routes import includeme
+
+import mock
+
+
+class TestIncludeMe(object):
+
+    def test_it_adds_some_routes(self):
+        config = mock.MagicMock()
+
+        includeme(config)
+
+        expected_calls = [
+            mock.call.add_route('about', '/'),
+            mock.call.add_route('token_callback', '/token_callback'),
+            mock.call.add_route('refresh_callback', '/refresh_callback'),
+            mock.call.add_route('config_xml', '/config.xml'),
+            mock.call.add_route('lti_credentials', '/lti_credentials'),
+            mock.call.add_route('lti_setup', '/lti_setup'),
+            mock.call.add_route('lti_submit', '/lti_submit'),
+            mock.call.add_route('lti_export', '/lti_export'),
+            mock.call.add_route('lti_serve_pdf', '/viewer/web/{file}.pdf'),
+            mock.call.add_route('catchall_pdf', '/viewer/*subpath'),
+        ]
+        for call in expected_calls:
+            assert call in config.mock_calls


### PR DESCRIPTION
This doesn't achieve anything except keeping the code tidier by
splitting into separate files, but - move all the Pyramid route
definitions (`add_route()` calls) into a separate `routes.py` file like
`h` does. The main `app.py` then does `config.include('lti.routes')`,
which runs the `includeme()` function in `app.py`, which is where the
`add_route()`s are now.

I also changed the `/config` route to `/config.xml` to match the example that Canvas gives, so when you add the app by URL in Canvas now you'll have to use `/config.xml`.

To test this just run `make dev` and check that some pages (e.g. the root `/` page of the app, the `/config.xml` page, the `/lti_credentials` page) are working.