### PR TITLE
Correct erroneous /token_init URL to /token_callback

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -103,7 +103,7 @@ To get the Canvas app running in a dev environment:
    google docs.
 
    Tip: In my developer key the **Redirect URI (Legacy)** is set to
-   `http://localhost:8001/token_init`.
+   `http://localhost:8001/token_callback`.
    
    In the Canvas app's settings I set the **Config URL** to
    `http://10.0.0.2:8001/config` because I have Canvas running inside a VM and

--- a/lti/views/oauth.py
+++ b/lti/views/oauth.py
@@ -105,8 +105,8 @@ def oauth_callback(request, type_=None):  # pylint: disable=too-many-locals
             'grant_type': grant_type,
             'client_id': oauth_consumer_key,
             'client_secret': canvas_client_secret,
-            'redirect_uri': '%s/token_init' % request.registry.settings['lti_server']  # this uri must match the uri in Developer Keys but is not called from
-        }                                                                              # canvas. rather it calls token_callback or refresh callback
+            'redirect_uri': '%s/token_callback' % request.registry.settings['lti_server']
+        }
         if grant_type == 'authorization_code':
             params['code'] = code
         else:

--- a/tests/lti/views/oauth_test.py
+++ b/tests/lti/views/oauth_test.py
@@ -231,7 +231,7 @@ class TestTokenCallback(object):
                 'client_secret': 'TEST_CLIENT_SECRET',
 
                 'client_id': u'TEST_OAUTH_CONSUMER_KEY',
-                'redirect_uri': 'http://TEST_LTI_SERVER.com/token_init',
+                'redirect_uri': 'http://TEST_LTI_SERVER.com/token_callback',
         })
 
 
@@ -254,7 +254,7 @@ class TestRefreshCallback(object):
                 'client_secret': 'TEST_CLIENT_SECRET',
 
                 'client_id': u'TEST_OAUTH_CONSUMER_KEY',
-                'redirect_uri': 'http://TEST_LTI_SERVER.com/token_init',
+                'redirect_uri': 'http://TEST_LTI_SERVER.com/token_callback',
         })
 
 


### PR DESCRIPTION
Our Canvas app was using `/token_callback` as the `redirect_uri` in the
OAuth 2.0 authorization request but then later, in the access token
request, it was using `/token_init` as the `redirect_uri`.

`/token_init` doesn't exist (404) and the OAuth 2.0 spec says that the
`redirect_uri` URI params in the two requests must be the same:

https://tools.ietf.org/html/rfc6749#section-4.1.3

So `/token_init` appears to have been a typo. Correct it to
`/token_callback`.

The docs also say to enter `/token_init` as the redirect URI when creating
the developer key in Canvas. Change this to `/token_callback` as well.

To test this:

1. Delete any developer keys from Canvas
2. Create a new developer key in Canvas following [the usual instructions](https://docs.google.com/document/d/13FFtk2qRogtU3qxR_oa3kq2ak-S_p7HHVnNM12eZGy8/edit) **but** using `/token_callback` instead of `/token_init` for the redirect URL
3. Delete the app from the course
4. Add the app to the course again
5. Delete any assignments
6. Make a new annotation assignment and launch it. Make it a PDF annotation so you can test the listing of PDF files to annotate (you must have uploaded some PDF files to the course)
7. Create a student account in Canvas and add it to the course
8. Login to the student account, launch the assignment, make some annotations, submit the assignment
9. Login to the teacher account again and see the student's submission in the speed grader