### PR TITLE
Move `app.py::token_init()` to `views.oauth.py::make_authorization_request()`

### DIFF
--- a/lti/app.py
+++ b/lti/app.py
@@ -178,7 +178,7 @@ def lti_setup(request):
 
     if lti_token is None:
         log.info ( 'lti_setup: getting token' )
-        return oauth.token_init(request, util.pack_state(post_data))
+        return oauth.make_authorization_request(request, util.pack_state(post_data))
 
     sess = requests.Session()  # ensure we have a token before calling lti_pdf or lti_web
     canvas_server = request.auth_data.get_canvas_server(oauth_consumer_key)

--- a/lti/views/oauth.py
+++ b/lti/views/oauth.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 # This isn't actually a view function yet but it probably should be.
-def token_init(request, state=None):
+def token_init(request, state):
     """
     Redirect the browser to Canvas's OAuth 2.0 login page.
 

--- a/tests/lti/views/oauth_test.py
+++ b/tests/lti/views/oauth_test.py
@@ -23,6 +23,63 @@ pytestmark = pytest.mark.usefixtures(
 
 
 @pytest.mark.usefixtures('util')
+class TestTokenInit(object):
+
+    def test_it_unpacks_the_state_param(self, pyramid_request, util):
+        oauth.token_init(pyramid_request, mock.sentinel.state)
+
+        util.unpack_state.assert_called_once_with(mock.sentinel.state)
+
+    def test_it_logs_an_error_if_the_state_param_isnt_valid_json(self,
+                                                                 pyramid_request,
+                                                                 util,
+                                                                 traceback,
+                                                                 log):
+        util.unpack_state.side_effect = ValueError()
+
+        returned = oauth.token_init(pyramid_request, mock.sentinel.state)
+
+        # It prints out the traceback.
+        traceback.print_exc.assert_called_once_with()
+
+        # It logs None.
+        log.error.assert_called_once_with(None)
+
+        # It returns a simple HTML page with None for its body.
+        util.simple_response.assert_called_once_with(None)
+        assert returned == util.simple_response.return_value
+
+    def test_it_gets_the_canvas_servers_url_from_the_database(self, pyramid_request):
+        oauth.token_init(pyramid_request, mock.sentinel.state)
+
+        pyramid_request.auth_data.get_canvas_server.assert_called_once_with(
+            'TEST_OAUTH_CONSUMER_KEY')
+
+    def test_it_redirects_the_browser_back_to_canvas_for_authorization(
+            self, pyramid_request):
+        returned = oauth.token_init(pyramid_request, mock.sentinel.state)
+
+        # It redirects the browser.
+        assert isinstance(returned, httpexceptions.HTTPFound)
+
+        # It redirects to the correct URL.
+        assert returned.location.startswith(
+            'https://TEST_CANVAS_SERVER.com/login/oauth2/auth')
+
+        # It puts the correct query params in the redirect URL.
+        # We actually have to parse the query string here because Python dicts
+        # are unordered which means that the _order_ of the different params
+        # in the query string can change each time the test is run.
+        parsed = urlparse.urlparse(returned.location)
+        assert urlparse.parse_qs(parsed.query) == {
+            'client_id': ['TEST_OAUTH_CONSUMER_KEY'],
+            'response_type': ['code'],
+            'redirect_uri': ['http://TEST_LTI_SERVER.com/token_callback'],
+            'state': ['sentinel.state'],
+        }
+
+
+@pytest.mark.usefixtures('util')
 @pytest.mark.parametrize('method', [oauth.token_callback, oauth.refresh_callback])
 class TestTokenCallbackAndRefreshCallback(object):
 

--- a/tests/lti/views/oauth_test.py
+++ b/tests/lti/views/oauth_test.py
@@ -19,10 +19,10 @@ pytestmark = pytest.mark.usefixtures(
     'requests_fixture',  # We never want tests to really send HTTP requests.
     'log',
     'traceback',
+    'util',
 )
 
 
-@pytest.mark.usefixtures('util')
 class TestTokenInit(object):
 
     def test_it_unpacks_the_state_param(self, pyramid_request, util):
@@ -79,7 +79,6 @@ class TestTokenInit(object):
         }
 
 
-@pytest.mark.usefixtures('util')
 @pytest.mark.parametrize('method', [oauth.token_callback, oauth.refresh_callback])
 class TestTokenCallbackAndRefreshCallback(object):
 
@@ -269,7 +268,6 @@ class TestTokenCallbackAndRefreshCallback(object):
         self.assert_that_it_logged_an_error(traceback, log, util, returned)
 
 
-@pytest.mark.usefixtures('util')
 class TestTokenCallback(object):
 
     """Unit tests for token_callback() only."""
@@ -292,7 +290,6 @@ class TestTokenCallback(object):
         })
 
 
-@pytest.mark.usefixtures('util')
 class TestRefreshCallback(object):
 
     """Unit tests for refresh_callback() only."""

--- a/tests/lti/views/oauth_test.py
+++ b/tests/lti/views/oauth_test.py
@@ -23,10 +23,10 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-class TestTokenInit(object):
+class TestMakeAuthorizationRequest(object):
 
     def test_it_unpacks_the_state_param(self, pyramid_request, util):
-        oauth.token_init(pyramid_request, mock.sentinel.state)
+        oauth.make_authorization_request(pyramid_request, mock.sentinel.state)
 
         util.unpack_state.assert_called_once_with(mock.sentinel.state)
 
@@ -37,7 +37,8 @@ class TestTokenInit(object):
                                                                  log):
         util.unpack_state.side_effect = ValueError()
 
-        returned = oauth.token_init(pyramid_request, mock.sentinel.state)
+        returned = oauth.make_authorization_request(pyramid_request,
+                                                    mock.sentinel.state)
 
         # It prints out the traceback.
         traceback.print_exc.assert_called_once_with()
@@ -50,14 +51,15 @@ class TestTokenInit(object):
         assert returned == util.simple_response.return_value
 
     def test_it_gets_the_canvas_servers_url_from_the_database(self, pyramid_request):
-        oauth.token_init(pyramid_request, mock.sentinel.state)
+        oauth.make_authorization_request(pyramid_request, mock.sentinel.state)
 
         pyramid_request.auth_data.get_canvas_server.assert_called_once_with(
             'TEST_OAUTH_CONSUMER_KEY')
 
     def test_it_redirects_the_browser_back_to_canvas_for_authorization(
             self, pyramid_request):
-        returned = oauth.token_init(pyramid_request, mock.sentinel.state)
+        returned = oauth.make_authorization_request(pyramid_request,
+                                                    mock.sentinel.state)
 
         # It redirects the browser.
         assert isinstance(returned, httpexceptions.HTTPFound)


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lti/pull/21

Move `app.py::token_init()` to `views.oauth.py::make_authorization_request()` and add tests and a docstring for it.

What the `token_init()` function actually does is make an [OAuth 2.0 authorization request](https://tools.ietf.org/html/rfc6749#section-4.1.1) to the Canvas API. This request is the first part of an [OAuth 2.0 authorization code grant](https://tools.ietf.org/html/rfc6749#section-4.1) flow, which is a back-and-forth series of requests between our app and Canvas that eventually results in us getting an access token and refresh token for the Canvas API.

As I move them into `oauth.py` I'm trying to rename all of the OAuth-related functions so that they use the same terminology as the OAuth 2.0 spec. Hence `make_authorization_request()` instead of `token_init()`. This is the first function, the rest still need to be renamed.

You can test this PR by setting your lti_token and lti_refresh_token to `null` in `canvas-auth.json` and then launching an annotation assignment. Canvas should ask you to authorize our app, then the assignment should launch, and if you look in `canvas-auth.json` an `lti_token` and `lti_refresh_token` should have appeared.