### PR TITLE
Remove refresh_init() function

### DIFF
--- a/lti/views/oauth.py
+++ b/lti/views/oauth.py
@@ -16,7 +16,7 @@ from lti import util
 log = logging.getLogger(__name__)
 
 
-def make_authorization_request(request, state):
+def make_authorization_request(request, state, refresh=False):
     """
     Send an OAuth 2.0 authorization request.
 
@@ -33,10 +33,18 @@ def make_authorization_request(request, state):
         log.info('make_authorization_request: state: %s', unpacked_state)
         oauth_consumer_key = unpacked_state[constants.OAUTH_CONSUMER_KEY]
         canvas_server = request.auth_data.get_canvas_server(oauth_consumer_key)
-        token_redirect_uri = '%s/login/oauth2/auth?client_id=%s&response_type=code&redirect_uri=%s/token_callback&state=%s' % (
+
+        if refresh:
+            redirect_uri = '%s/refresh_callback'
+        else:
+            redirect_uri = '%s/token_callback'
+
+        redirect_uri = redirect_uri % request.registry.settings['lti_server']
+
+        token_redirect_uri = '%s/login/oauth2/auth?client_id=%s&response_type=code&redirect_uri=%s&state=%s' % (
             canvas_server,
             oauth_consumer_key,
-            request.registry.settings['lti_server'],
+            redirect_uri,
             state
         )
         ret = HTTPFound(location=token_redirect_uri)

--- a/tests/lti/views/oauth_test.py
+++ b/tests/lti/views/oauth_test.py
@@ -80,6 +80,19 @@ class TestMakeAuthorizationRequest(object):
             'state': ['sentinel.state'],
         }
 
+    def test_the_refresh_arg_changes_the_redirect_uri(self, pyramid_request):
+        # If you pass refresh=True then it sends /refresh_callback instead of
+        # /token_callback as the redirect_uri.
+
+        returned = oauth.make_authorization_request(pyramid_request,
+                                                    mock.sentinel.state,
+                                                    refresh=True)
+
+        parsed = urlparse.urlparse(returned.location)
+        assert urlparse.parse_qs(parsed.query)['redirect_uri'] == [
+            'http://TEST_LTI_SERVER.com/refresh_callback'
+        ]
+
 
 @pytest.mark.parametrize('method', [oauth.token_callback, oauth.refresh_callback])
 class TestTokenCallbackAndRefreshCallback(object):


### PR DESCRIPTION
Depends on https://github.com/hypothesis/lti/pull/22

Delete the refresh_init() function

This function is exactly the same as make_authorization_request()
(formerly token_init()) except that it sends /refresh_callback instead of
/token_callback as the redirect_uri.

Just add an option to make_authorization_request() to toggle the
redirect_uri instead.

I've got a feeling that in the future we may get rid of this
/refresh_callback redirect_uri anyway.

To test this:

1. Change the lti_token in canvas-auth.json to "abc". Leave lti_refresh_token the same
2. Launch an assignment

You should see that `make_authorization_request()` gets called with `refresh=True` and a new access and refresh token appear in canvas-auth.json.