### PR TITLE
Extract lti_pdf()

### DIFF
--- a/lti/app.py
+++ b/lti/app.py
@@ -1,11 +1,8 @@
-﻿import json
-import urllib
+﻿import urllib
 import urlparse
 import requests
 import traceback
-import os
 import re
-import md5
 import logging
 import filelock
 from pyramid.httpexceptions import HTTPFound
@@ -20,6 +17,7 @@ from lti import util
 from lti import constants
 from lti.views import oauth
 from lti.views import web
+from lti.views import pdf
 
 
 log = logging.getLogger(__name__)
@@ -132,7 +130,7 @@ def lti_setup(request):
     assignment_value = post_data[constants.ASSIGNMENT_VALUE]
 
     if assignment_type == 'pdf':
-        return lti_pdf(request, oauth_consumer_key=oauth_consumer_key, lis_outcome_service_url=lis_outcome_service_url, lis_result_sourcedid=lis_result_sourcedid, course=course, name=assignment_name, value=assignment_value)
+        return pdf.lti_pdf(request, oauth_consumer_key=oauth_consumer_key, lis_outcome_service_url=lis_outcome_service_url, lis_result_sourcedid=lis_result_sourcedid, course=course, name=assignment_name, value=assignment_value)
 
     if assignment_type == 'web':
         return web.web_response(request.registry.settings,
@@ -170,71 +168,6 @@ def lti_setup(request):
         launch_url=launch_url_template,
         pdf_choices=pdf_choices,
     )))
-
-def lti_pdf(request, oauth_consumer_key=None, lis_outcome_service_url=None, lis_result_sourcedid=None, course=None, name=None, value=None):
-    """ 
-    Called from lti_setup if it was called from a pdf assignment. 
-
-    We expect to know at least the oauth_consume_key, course number, name of the PDF, 
-    and value of the PDF (its number as known to the Canvas API)
-
-    If we are called in a student context we also expect the lis* params needed for the submission URL.
-
-    Download the PDF to a timestamp-based name in the PDFJS subtree, and call pdf_response to 
-    return a page that serves it back in an iframe.
-    """
-    log.info ( 'lti_pdf: query: %s' % request.query_string )
-    log.info ( 'lti_pdf: post: %s' % request.POST )
-    post_data = util.requests.capture_post_data(request)
-    if oauth_consumer_key is None:
-        oauth_consumer_key = util.requests.get_post_or_query_param(request, constants.OAUTH_CONSUMER_KEY)
-    file_id = value
-    try:
-        lti_token = request.auth_data.get_lti_token(oauth_consumer_key)
-    except:
-        return util.simple_response("We don't have the Consumer Key %s in our database yet." % oauth_consumer_key)
-    canvas_server = request.auth_data.get_canvas_server(oauth_consumer_key)
-    url = '%s/api/v1/courses/%s/files/%s' % (canvas_server, course, file_id)
-    m = md5.new()
-    m.update('%s/%s/%s' % ( canvas_server, course, file_id ))
-    hash = m.hexdigest()
-    log.info( 'server %s, course %s, file_id %s, hash %s' % ( canvas_server, course, file_id, hash ))
-    if util.filecache.exists_pdf(hash) is False:
-        sess = requests.Session()
-        r = sess.get(url=url, headers={'Authorization':'Bearer %s' % lti_token})
-        if r.status_code == 401:
-          log.info( 'lti_pdf: refreshing token' )
-          return oauth.make_authorization_request(
-                request, 'pdf:' + urllib.quote(json.dumps(post_data)),
-                refresh=True)
-        if r.status_code == 200:
-            j = r.json()
-            log.info( j )
-            url = j['url']
-            log.info( url )
-            urllib.urlretrieve(url, hash)
-            os.rename(hash, '%s/%s.pdf' % (constants.FILES_PATH, hash))
-        else:
-            log.error('%s retrieving %s, %s, %s' % (r.status_code, canvas_server, course, file_id))
-    fingerprint = util.pdf.get_fingerprint(hash)
-    if fingerprint is None:
-        pdf_uri = '%s/viewer/web/%s.pdf' % ( request.registry.settings['lti_server'], hash )
-    else:
-        pdf_uri = 'urn:x-pdf:%s' % fingerprint
-
-    return Response(
-        render('lti:templates/pdf_assignment.html.jinja2', dict(
-                name=name,
-                hash=hash,
-                oauth_consumer_key=oauth_consumer_key,
-                lis_outcome_service_url=lis_outcome_service_url,
-                lis_result_sourcedid=lis_result_sourcedid,
-                doc_uri=pdf_uri,
-                lti_server=request.registry.settings['lti_server'],
-            ),
-        ).encode('utf-8'),
-        content_type='text/html',
-    )
 
 @view_config( route_name='lti_submit' )
 def lti_submit(request, oauth_consumer_key=None, lis_outcome_service_url=None, lis_result_sourcedid=None, export_url=None):

--- a/lti/app.py
+++ b/lti/app.py
@@ -171,9 +171,6 @@ def lti_setup(request):
         pdf_choices=pdf_choices,
     )))
 
-def exists_pdf(hash):
-    return os.path.isfile('%s/%s.pdf' % (constants.FILES_PATH, hash))
-
 def lti_pdf(request, oauth_consumer_key=None, lis_outcome_service_url=None, lis_result_sourcedid=None, course=None, name=None, value=None):
     """ 
     Called from lti_setup if it was called from a pdf assignment. 
@@ -202,7 +199,7 @@ def lti_pdf(request, oauth_consumer_key=None, lis_outcome_service_url=None, lis_
     m.update('%s/%s/%s' % ( canvas_server, course, file_id ))
     hash = m.hexdigest()
     log.info( 'server %s, course %s, file_id %s, hash %s' % ( canvas_server, course, file_id, hash ))
-    if exists_pdf(hash) is False:
+    if util.filecache.exists_pdf(hash) is False:
         sess = requests.Session()
         r = sess.get(url=url, headers={'Authorization':'Bearer %s' % lti_token})
         if r.status_code == 401:

--- a/lti/util/__init__.py
+++ b/lti/util/__init__.py
@@ -9,6 +9,8 @@ from pyramid.response import Response
 from pyramid.renderers import render
 
 from lti.util import pdf
+from lti.util import requests
+from lti.util import filecache
 
 
 def pack_state(data):
@@ -56,4 +58,6 @@ __all__ = (
     'pdf',
     'unpack_state',
     'simple_response',
+    'requests',
+    'filecache',
 )

--- a/lti/util/filecache.py
+++ b/lti/util/filecache.py
@@ -12,3 +12,8 @@ from lti import constants
 def exists_html(hash_):
     """Return True if an HTML file with the given hash is already cached."""
     return os.path.isfile('%s/%s.html' % (constants.FILES_PATH, hash_))
+
+
+def exists_pdf(hash_):
+    """Return True if a PDF file with the given hash is already cached."""
+    return os.path.isfile('%s/%s.pdf' % (constants.FILES_PATH, hash_))

--- a/lti/views/pdf.py
+++ b/lti/views/pdf.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import md5
+import urllib
+import os
+import json
+
+import requests
+from pyramid.renderers import render
+from pyramid.response import Response
+
+from lti import util
+from lti.views import oauth
+from lti import constants
+
+
+def lti_pdf(request, oauth_consumer_key, lis_outcome_service_url,
+            lis_result_sourcedid, course, name, value):
+    """ 
+    Called from lti_setup if it was called from a pdf assignment. 
+
+    We expect to know at least the oauth_consume_key, course number, name of the PDF, 
+    and value of the PDF (its number as known to the Canvas API)
+
+    If we are called in a student context we also expect the lis* params needed for the submission URL.
+
+    Download the PDF to a timestamp-based name in the PDFJS subtree, and call pdf_response to 
+    return a page that serves it back in an iframe.
+    """
+    post_data = util.requests.capture_post_data(request)
+    file_id = value
+    try:
+        lti_token = request.auth_data.get_lti_token(oauth_consumer_key)
+    except:
+        return util.simple_response("We don't have the Consumer Key %s in our database yet." % oauth_consumer_key)
+    canvas_server = request.auth_data.get_canvas_server(oauth_consumer_key)
+    url = '%s/api/v1/courses/%s/files/%s' % (canvas_server, course, file_id)
+    m = md5.new()
+    m.update('%s/%s/%s' % ( canvas_server, course, file_id ))
+    hash = m.hexdigest()
+    if util.filecache.exists_pdf(hash) is False:
+        sess = requests.Session()
+        r = sess.get(url=url, headers={'Authorization':'Bearer %s' % lti_token})
+        if r.status_code == 401:
+          return oauth.make_authorization_request(
+                request, 'pdf:' + urllib.quote(json.dumps(post_data)),
+                refresh=True)
+        if r.status_code == 200:
+            j = r.json()
+            url = j['url']
+            urllib.urlretrieve(url, hash)
+            os.rename(hash, '%s/%s.pdf' % (constants.FILES_PATH, hash))
+    fingerprint = util.pdf.get_fingerprint(hash)
+    if fingerprint is None:
+        pdf_uri = '%s/viewer/web/%s.pdf' % ( request.registry.settings['lti_server'], hash )
+    else:
+        pdf_uri = 'urn:x-pdf:%s' % fingerprint
+
+    return Response(
+        render('lti:templates/pdf_assignment.html.jinja2', dict(
+                name=name,
+                hash=hash,
+                oauth_consumer_key=oauth_consumer_key,
+                lis_outcome_service_url=lis_outcome_service_url,
+                lis_result_sourcedid=lis_result_sourcedid,
+                doc_uri=pdf_uri,
+                lti_server=request.registry.settings['lti_server'],
+            ),
+        ).encode('utf-8'),
+        content_type='text/html',
+    )
+

--- a/lti/views/pdf.py
+++ b/lti/views/pdf.py
@@ -16,59 +16,59 @@ from lti.views import oauth
 from lti import constants
 
 
+# pylint: disable = too-many-arguments, too-many-locals
 def lti_pdf(request, oauth_consumer_key, lis_outcome_service_url,
             lis_result_sourcedid, course, name, value):
-    """ 
-    Called from lti_setup if it was called from a pdf assignment. 
+    """
+    Return a PDF annotation assignment (HTML response).
 
-    We expect to know at least the oauth_consume_key, course number, name of the PDF, 
-    and value of the PDF (its number as known to the Canvas API)
+    Download the PDF file to be annotated from Canvas's API and save it to a
+    cache directory on disk, if the file hasn't been cached already.
 
-    If we are called in a student context we also expect the lis* params needed for the submission URL.
+    This requires an access token for the Canvas API. If we don't have one then
+    kick off an authorization code flow to get one, redirecting the browser to
+    Canvas's auth endpoint. We'll end up rendering the annotation assignment
+    later, after Canvas directs the browser back to us with an authorization.
 
-    Download the PDF to a timestamp-based name in the PDFJS subtree, and call pdf_response to 
-    return a page that serves it back in an iframe.
     """
     post_data = util.requests.capture_post_data(request)
     file_id = value
     try:
         lti_token = request.auth_data.get_lti_token(oauth_consumer_key)
-    except:
+    except KeyError:
         return util.simple_response("We don't have the Consumer Key %s in our database yet." % oauth_consumer_key)
     canvas_server = request.auth_data.get_canvas_server(oauth_consumer_key)
     url = '%s/api/v1/courses/%s/files/%s' % (canvas_server, course, file_id)
-    m = md5.new()
-    m.update('%s/%s/%s' % ( canvas_server, course, file_id ))
-    hash = m.hexdigest()
-    if util.filecache.exists_pdf(hash) is False:
+    md5_obj = md5.new()
+    md5_obj.update('%s/%s/%s' % (canvas_server, course, file_id))
+    digest = md5_obj.hexdigest()
+    if util.filecache.exists_pdf(digest) is False:
         sess = requests.Session()
-        r = sess.get(url=url, headers={'Authorization':'Bearer %s' % lti_token})
-        if r.status_code == 401:
-          return oauth.make_authorization_request(
+        response = sess.get(url=url, headers={'Authorization': 'Bearer %s' % lti_token})
+        if response.status_code == 401:
+            return oauth.make_authorization_request(
                 request, 'pdf:' + urllib.quote(json.dumps(post_data)),
                 refresh=True)
-        if r.status_code == 200:
-            j = r.json()
+        if response.status_code == 200:
+            j = response.json()
             url = j['url']
-            urllib.urlretrieve(url, hash)
-            os.rename(hash, '%s/%s.pdf' % (constants.FILES_PATH, hash))
-    fingerprint = util.pdf.get_fingerprint(hash)
+            urllib.urlretrieve(url, digest)
+            os.rename(digest, '%s/%s.pdf' % (constants.FILES_PATH, digest))
+    fingerprint = util.pdf.get_fingerprint(digest)
     if fingerprint is None:
-        pdf_uri = '%s/viewer/web/%s.pdf' % ( request.registry.settings['lti_server'], hash )
+        pdf_uri = '%s/viewer/web/%s.pdf' % (request.registry.settings['lti_server'], digest)
     else:
         pdf_uri = 'urn:x-pdf:%s' % fingerprint
 
     return Response(
         render('lti:templates/pdf_assignment.html.jinja2', dict(
-                name=name,
-                hash=hash,
-                oauth_consumer_key=oauth_consumer_key,
-                lis_outcome_service_url=lis_outcome_service_url,
-                lis_result_sourcedid=lis_result_sourcedid,
-                doc_uri=pdf_uri,
-                lti_server=request.registry.settings['lti_server'],
-            ),
-        ).encode('utf-8'),
+               name=name,
+               hash=digest,
+               oauth_consumer_key=oauth_consumer_key,
+               lis_outcome_service_url=lis_outcome_service_url,
+               lis_result_sourcedid=lis_result_sourcedid,
+               doc_uri=pdf_uri,
+               lti_server=request.registry.settings['lti_server'],
+               )).encode('utf-8'),
         content_type='text/html',
     )
-

--- a/tests/lti/conftest.py
+++ b/tests/lti/conftest.py
@@ -42,6 +42,7 @@ def pyramid_request():
     pyramid_request.auth_data = mock.create_autospec(AuthData, instance=True)
     pyramid_request.auth_data.get_canvas_server.return_value = 'https://TEST_CANVAS_SERVER.com'
     pyramid_request.auth_data.get_lti_secret.return_value = 'TEST_CLIENT_SECRET'
+    pyramid_request.auth_data.get_lti_token.return_value = 'TEST_OAUTH_ACCESS_TOKEN'
     pyramid_request.auth_data.get_lti_refresh_token.return_value = 'TEST_OAUTH_REFRESH_TOKEN'
 
     pyramid_request.POST.update({

--- a/tests/lti/util/filecache_test.py
+++ b/tests/lti/util/filecache_test.py
@@ -8,7 +8,7 @@ import pytest
 
 
 @pytest.mark.usefixtures('os')
-class TestExistsHHTML(object):
+class TestExistsHTML(object):
 
     def test_it_calls_isfile_with_the_correct_path(self, os):
         filecache.exists_html(hash_='abc123')
@@ -21,6 +21,26 @@ class TestExistsHHTML(object):
         os.path.isfile.return_value = isfile_return_value
 
         assert filecache.exists_html(hash_='abc123') == isfile_return_value
+
+    @pytest.fixture
+    def os(self, patch):
+        return patch('lti.util.filecache.os')
+
+
+@pytest.mark.usefixtures('os')
+class TestExistsPDF(object):
+
+    def test_it_calls_isfile_with_the_correct_path(self, os):
+        filecache.exists_pdf(hash_='abc123')
+
+        os.path.isfile.assert_called_once_with(
+            './lti/static/pdfjs/viewer/web/abc123.pdf')
+
+    @pytest.mark.parametrize('isfile_return_value', [True, False])
+    def test_it_returns_what_isfile_returns(self, os, isfile_return_value):
+        os.path.isfile.return_value = isfile_return_value
+
+        assert filecache.exists_pdf(hash_='abc123') == isfile_return_value
 
     @pytest.fixture
     def os(self, patch):

--- a/tests/lti/views/pdf_test.py
+++ b/tests/lti/views/pdf_test.py
@@ -81,10 +81,10 @@ class TestLTIPDF(object):
 
         util.filecache.exists_pdf.assert_called_once_with(self.expected_digest())
 
-    def test_if_the_file_isnt_cached_it_gets_file_metadata_canvas(self,
-                                                                  pyramid_request,
-                                                                  requests,
-                                                                  util):
+    def test_if_the_file_isnt_cached_it_gets_the_file_metadata_from_canvas(self,
+                                                                           pyramid_request,
+                                                                           requests,
+                                                                           util):
         util.filecache.exists_pdf.return_value = False
 
         pdf.lti_pdf(

--- a/tests/lti/views/pdf_test.py
+++ b/tests/lti/views/pdf_test.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import md5
+
+import pytest
+import mock
+
+from lti.views import pdf
+
+
+@pytest.mark.usefixtures('requests',
+                         'util',
+                         'render',
+                         'oauth',
+                         'urlretrieve',
+                         'os',
+                         'Response')
+class TestLTIPDF(object):
+
+    def test_it_gets_the_access_token_from_the_db(self, pyramid_request):
+        pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        pyramid_request.auth_data.get_lti_token.assert_called_once_with(
+            'TEST_OAUTH_CONSUMER_KEY')
+
+    def test_it_shows_an_error_page_if_we_dont_have_the_consumer_key(self,
+                                                                     pyramid_request,
+                                                                     util):
+        pyramid_request.auth_data.get_lti_token.side_effect = KeyError
+
+        response = pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        util.simple_response.assert_called_once_with(
+            "We don't have the Consumer Key TEST_OAUTH_CONSUMER_KEY in our database yet.")
+        assert response == util.simple_response.return_value
+
+    def test_it_gets_the_canvas_servers_url_from_the_db(self, pyramid_request):
+        pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        pyramid_request.auth_data.get_canvas_server.assert_called_once_with(
+            'TEST_OAUTH_CONSUMER_KEY')
+
+    def test_it_checks_whether_the_pdf_file_is_already_cached(self,
+                                                              pyramid_request,
+                                                              util):
+        pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        util.filecache.exists_pdf.assert_called_once_with(self.expected_digest())
+
+    def test_if_the_file_isnt_cached_it_gets_file_metadata_canvas(self,
+                                                                  pyramid_request,
+                                                                  requests,
+                                                                  util):
+        util.filecache.exists_pdf.return_value = False
+
+        pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        requests.Session.assert_called_once_with()
+        requests.Session.return_value.get.assert_called_once_with(
+            url='https://TEST_CANVAS_SERVER.com/api/v1/courses/TEST_COURSE/files/TEST_VALUE',
+            headers={'Authorization': 'Bearer TEST_OAUTH_ACCESS_TOKEN'})
+
+    # If the Canvas API returns a 401 Unauthorized when we try to access the
+    # PDF file metadata then it kicks off an OAuth 2.0 authorization code flow.
+    def test_if_the_canvas_api_401s_it_starts_an_oauth_flow(self,
+                                                            pyramid_request,
+                                                            requests,
+                                                            oauth,
+                                                            util):
+        util.filecache.exists_pdf.return_value = False
+        requests.Session.return_value.get.return_value.status_code = 401
+
+        # In production capture_post_data() would return several parameters
+        # that Canvas POSTed to us. For this test we'll just make it simple.
+        util.requests.capture_post_data.return_value = {'foo': 'bar'}
+
+        response = pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        # It captures certain of the parameters the Canvas POSTs to us.
+        # Later it will pass them to oauth.make_authorization_request().
+        util.requests.capture_post_data.assert_called_once_with(pyramid_request)
+
+        oauth.make_authorization_request.assert_called_once_with(
+            pyramid_request,
+            # This is the dict that capture_post_data() returned, dumped to
+            # JSON and URL-quoted, and with "pdf:" prepended.
+            'pdf:%7B%22foo%22%3A%20%22bar%22%7D',
+            refresh=True)
+
+        assert response == oauth.make_authorization_request.return_value
+
+    def test_if_the_canvas_api_200s_it_downloads_the_PDF_file(self,
+                                                              pyramid_request,
+                                                              requests,
+                                                              urlretrieve,
+                                                              util):
+        util.filecache.exists_pdf.return_value = False
+        requests.Session.return_value.get.return_value.status_code = 200
+        requests.Session.return_value.get.return_value.json.return_value = {
+            'url': 'THE_URL_OF_THE_PDF_FILE',
+        }
+
+        response = pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        urlretrieve.assert_called_once_with(
+            'THE_URL_OF_THE_PDF_FILE',
+            self.expected_digest(),
+        )
+
+    def test_it_moves_the_downloaded_file_into_the_FILES_PATH_folder(self,
+                                                                     pyramid_request,
+                                                                     util,
+                                                                     requests,
+                                                                     os):
+        util.filecache.exists_pdf.return_value = False
+        requests.Session.return_value.get.return_value.status_code = 200
+
+        pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        expected_digest = self.expected_digest()
+        os.rename.assert_called_once_with(
+            expected_digest,
+            './lti/static/pdfjs/viewer/web/' + expected_digest + '.pdf',
+        )
+
+    def test_it_renders_the_pdf_assignment_template(self,
+                                                    pyramid_request,
+                                                    render,
+                                                    Response,
+                                                    util):
+        util.pdf.get_fingerprint.return_value = None
+
+        response = pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        expected_digest = self.expected_digest()
+        render.assert_called_once_with(
+            'lti:templates/pdf_assignment.html.jinja2', dict(
+                name='TEST_NAME',
+                hash=expected_digest,
+                oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+                lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+                lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+                doc_uri='http://TEST_LTI_SERVER.com/viewer/web/' + expected_digest + '.pdf',
+                lti_server='http://TEST_LTI_SERVER.com',
+        ))
+        Response.assert_called_once_with(
+            render.return_value.encode.return_value, content_type='text/html')
+        assert response == Response.return_value
+
+    def test_if_get_fingerprint_returns_a_value_it_uses_that_as_pdf_uri_instead(
+            self, pyramid_request, util, render):
+        util.pdf.get_fingerprint.return_value = 'abc123'
+
+        pdf.lti_pdf(
+            pyramid_request,
+            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
+            course='TEST_COURSE',
+            name='TEST_NAME',
+            value='TEST_VALUE',
+        )
+
+        assert render.call_args[0][1]['doc_uri'] == 'urn:x-pdf:abc123'
+
+    def expected_digest(self):
+        """Return the MD5 digest we expect lti_pdf() to cache the file with."""
+        md5_obj = md5.new()
+        md5_obj.update('https://TEST_CANVAS_SERVER.com/TEST_COURSE/TEST_VALUE')
+        return md5_obj.hexdigest()
+
+    @pytest.fixture
+    def requests(self, patch):
+        return patch('lti.views.pdf.requests')
+
+    @pytest.fixture
+    def util(self, patch):
+        util = patch('lti.views.pdf.util')
+        return util
+
+    @pytest.fixture
+    def render(self, patch):
+        return patch('lti.views.pdf.render')
+
+    @pytest.fixture
+    def oauth(self, patch):
+        return patch('lti.views.pdf.oauth')
+
+    @pytest.fixture
+    def urlretrieve(self, patch):
+        return patch('lti.views.pdf.urllib.urlretrieve')
+
+    @pytest.fixture
+    def os(self, patch):
+        return patch('lti.views.pdf.os')
+
+    @pytest.fixture
+    def Response(self, patch):
+        return patch('lti.views.pdf.Response')


### PR DESCRIPTION
This extracts `lti_pdf()`, the function responsible for rendering PDF annotation assignments (including downloading PDF files from Canvas and caching them to the local filesystem) out into a separate file and adds tests and a docstring and lints the function. `exists_pdf()`, which `lti_pdf()` uses, is also extracted.