### PR TITLE
Fix linting of tests

### DIFF
--- a/tests/.prospector.yaml
+++ b/tests/.prospector.yaml
@@ -4,7 +4,7 @@
 # want to lint the tests, but I don't want to apply exactly the same lint rules
 # to the tests as to the production code.
 inherits:
-    - .prospector.base
+    - ../.prospector.base
 test-warnings: true
 pylint:
   options:
@@ -16,5 +16,3 @@ pylint:
     - no-self-use  # There are often reasons to group test methods into classes
                    # even if they don't use self.
     - redefined-outer-name # Pytest fixtures always break this rule.
-ignore-paths:
-  - lti/

--- a/tests/.prospector.yaml
+++ b/tests/.prospector.yaml
@@ -8,11 +8,15 @@ inherits:
 test-warnings: true
 pylint:
   options:
-    # Allow function and method names in tests to be longer and to contain
-    # capital letters.
+    # Allow names in tests to be longer and to contain capital letters.
+    argument-rgx: "[a-zA-Z_][a-zA-Z0-9_]{2,30}$"
     function-rgx: "[a-zA-Z_][a-zA-Z0-9_]{2,70}$"
     method-rgx: "[a-zA-Z_][a-zA-Z0-9_]{2,70}$"
   disable:
     - no-self-use  # There are often reasons to group test methods into classes
                    # even if they don't use self.
     - redefined-outer-name # Pytest fixtures always break this rule.
+pep8:
+  disable:
+    - N802  # Function name should be lower case
+    - N803  # Argument name should be lower case

--- a/tests/lti/config/__init___test.py
+++ b/tests/lti/config/__init___test.py
@@ -21,7 +21,7 @@ class TestConfigure(object):
 
     def test_it_returns_a_Configurator_with_all_the_settings(self,
                                                              env_setting):
-        def env_setting_side_effect(envvar_name, required=False, default=None):
+        def env_setting_side_effect(envvar_name, required=False, default=None):  # pylint:disable=unused-argument
             return {
                 'LTI_FILES_PATH': 'the_lti_files_path_setting',
                 'LTI_SERVER': 'the_lti_server_setting',

--- a/tests/lti/config/settings_test.py
+++ b/tests/lti/config/settings_test.py
@@ -4,10 +4,7 @@ from __future__ import unicode_literals
 
 import pytest
 
-from lti.config.settings import (
-    SettingError,
-    env_setting,
-)
+from lti.config import settings
 
 
 @pytest.mark.usefixtures('os_fixture')
@@ -16,36 +13,36 @@ class TestEnvSetting(object):
     def test_it_returns_the_value_from_the_environment_variable(self, os_fixture):
         os_fixture.environ = {'FOOBAR': 'the_value'}
 
-        result = env_setting('FOOBAR')
+        result = settings.env_setting('FOOBAR')
 
         assert result == 'the_value'
 
     def test_it_returns_none_when_environment_variable_isnt_set_and_optional(self, os_fixture):
         os_fixture.environ = {}
 
-        result = env_setting('FOOBAR')
+        result = settings.env_setting('FOOBAR')
 
         assert result is None
 
     def test_it_raises_if_the_environment_variable_isnt_set_and_required(self, os_fixture):
         os_fixture.environ = {}
 
-        with pytest.raises(SettingError) as exc_info:
-            env_setting('FOOBAR', required=True)
+        with pytest.raises(settings.SettingError) as exc_info:
+            settings.env_setting('FOOBAR', required=True)
 
         assert exc_info.value.message == "environment variable FOOBAR isn't set"
 
     def test_environment_variables_override_default_settings(self, os_fixture):
         os_fixture.environ = {'FOOBAR': 'the_value'}
 
-        result = env_setting('FOOBAR', default='DEFAULT')
+        result = settings.env_setting('FOOBAR', default='DEFAULT')
 
         assert result == 'the_value'
 
     def test_if_a_default_is_given_and_theres_no_env_var_it_returns_the_default(self, os_fixture):
         os_fixture.environ = {}
 
-        result = env_setting('FOOBAR', default='DEFAULT')
+        result = settings.env_setting('FOOBAR', default='DEFAULT')
 
         assert result == 'DEFAULT'
 

--- a/tests/lti/conftest.py
+++ b/tests/lti/conftest.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import sessionmaker
 
 from lti import constants
 from lti import db
-from lti.services.auth_data import AuthDataService
+from lti.services import auth_data
 
 
 TEST_DATABASE_URL = os.environ.get(
@@ -34,7 +34,7 @@ def db_engine():
 @pytest.yield_fixture
 def db_session(db_engine):
     """
-    The SQLAlchemy session object.
+    Yield the SQLAlchemy session object.
 
     We enable fast repeatable database tests by setting up the database only
     once per session (see :func:`db_engine`) and then wrapping each test
@@ -52,8 +52,8 @@ def db_session(db_engine):
     session.begin_nested()
 
     @sqlalchemy.event.listens_for(session, "after_transaction_end")
-    def restart_savepoint(session, transaction):
-        if transaction.nested and not transaction._parent.nested:
+    def restart_savepoint(session, transaction):  # pylint:disable=unused-variable
+        if transaction.nested and not transaction._parent.nested:  # pylint:disable=protected-access
             session.begin_nested()
 
     try:
@@ -126,7 +126,7 @@ def pyramid_config(pyramid_request):
 
         apply_request_extensions(pyramid_request)
 
-        auth_data_svc = mock.create_autospec(AuthDataService, instance=True)
+        auth_data_svc = mock.create_autospec(auth_data.AuthDataService, instance=True)
         auth_data_svc.get_canvas_server.return_value = 'https://TEST_CANVAS_SERVER.com'
         auth_data_svc.get_lti_secret.return_value = 'TEST_CLIENT_SECRET'
         auth_data_svc.get_lti_token.return_value = 'TEST_OAUTH_ACCESS_TOKEN'
@@ -151,7 +151,7 @@ def routes(pyramid_config):
 
 @pytest.yield_fixture
 def factories(db_session):
-    import factories
+    import factories  # pylint:disable=relative-import
     factories.set_session(db_session)
     yield factories
     factories.set_session(None)

--- a/tests/lti/factories.py
+++ b/tests/lti/factories.py
@@ -12,16 +12,15 @@ SESSION = None
 
 
 def set_session(value):
-    global SESSION
+    global SESSION  # pylint:disable=global-statement
 
     SESSION = value
 
 
 class ModelFactory(factory.alchemy.SQLAlchemyModelFactory):
-
     """Base class for all factory classes for model classes."""
 
-    class Meta:
+    class Meta(object):
         abstract = True
 
     @classmethod
@@ -42,7 +41,7 @@ class ModelFactory(factory.alchemy.SQLAlchemyModelFactory):
 
 class OAuth2Credentials(ModelFactory):
 
-    class Meta:
+    class Meta(object):
         model = models.OAuth2Credentials
         sqlalchemy_session_persistence = 'flush'
 
@@ -53,7 +52,7 @@ class OAuth2Credentials(ModelFactory):
 
 class OAuth2AccessToken(ModelFactory):
 
-    class Meta:
+    class Meta(object):
         model = models.OAuth2AccessToken
         sqlalchemy_session_persistence = 'flush'
 

--- a/tests/lti/models/test_oauth2_access_token.py
+++ b/tests/lti/models/test_oauth2_access_token.py
@@ -6,7 +6,6 @@ from sqlalchemy.exc import IntegrityError
 import pytest
 
 from lti.models import OAuth2AccessToken
-from lti.models import OAuth2Credentials
 
 
 class TestOAuth2AccessToken(object):
@@ -23,8 +22,8 @@ class TestOAuth2AccessToken(object):
         assert persisted.access_token == "TEST_ACCESS_TOKEN"
         assert persisted.refresh_token == "TEST_REFRESH_TOKEN"
 
-    def test_the_OAuth2Credentials_object_is_accessible_as_the_credentials_property(self,
-                                                                                    oauth2_credentials):
+    def test_the_OAuth2Credentials_is_accessible_as_the_credentials_property(self,
+                                                                             oauth2_credentials):
         access_token = OAuth2AccessToken(credentials=oauth2_credentials,
                                          access_token="TEST_ACCESS_TOKEN",
                                          refresh_token="TEST_REFRESH_TOKEN")

--- a/tests/lti/models/test_oauth2_credentials.py
+++ b/tests/lti/models/test_oauth2_credentials.py
@@ -78,7 +78,7 @@ class TestOAuth2Credentials(object):
     def test_client_secret_is_required(self, db_session):
         db_session.add(OAuth2Credentials(client_id="TEST_ID",
                                          authorization_server="TEST_AUTH_SERVER"))
-       
+
         with pytest.raises(IntegrityError):
             db_session.flush()
 

--- a/tests/lti/models/test_oauth2_unvalidated_credentials.py
+++ b/tests/lti/models/test_oauth2_unvalidated_credentials.py
@@ -8,10 +8,11 @@ from lti.models import OAuth2UnvalidatedCredentials
 class TestOAuthUnvalidated2Credentials(object):
 
     def test_it_persists_the_fields(self, db_session):
-        db_session.add(OAuth2UnvalidatedCredentials(client_id="TEST_ID",
-                                                    client_secret="TEST_SECRET",
-                                                    authorization_server="TEST_AUTH_SERVER",
-                                                    email_address="TEST_EMAIL",
+        db_session.add(OAuth2UnvalidatedCredentials(
+            client_id="TEST_ID",
+            client_secret="TEST_SECRET",
+            authorization_server="TEST_AUTH_SERVER",
+            email_address="TEST_EMAIL",
         ))
 
         persisted = (db_session.query(OAuth2UnvalidatedCredentials)
@@ -23,20 +24,23 @@ class TestOAuthUnvalidated2Credentials(object):
 
     def test_you_can_add_multiple_rows_with_the_same_values(self, db_session):
         db_session.add_all([
-            OAuth2UnvalidatedCredentials(client_id="TEST_ID",
-                                         client_secret="TEST_SECRET",
-                                         authorization_server="TEST_AUTH_SERVER",
-                                         email_address="TEST_EMAIL",
+            OAuth2UnvalidatedCredentials(
+                client_id="TEST_ID",
+                client_secret="TEST_SECRET",
+                authorization_server="TEST_AUTH_SERVER",
+                email_address="TEST_EMAIL",
             ),
-            OAuth2UnvalidatedCredentials(client_id="TEST_ID",
-                                         client_secret="TEST_SECRET",
-                                         authorization_server="TEST_AUTH_SERVER",
-                                         email_address="TEST_EMAIL",
+            OAuth2UnvalidatedCredentials(
+                client_id="TEST_ID",
+                client_secret="TEST_SECRET",
+                authorization_server="TEST_AUTH_SERVER",
+                email_address="TEST_EMAIL",
             ),
-            OAuth2UnvalidatedCredentials(client_id="TEST_ID",
-                                         client_secret="TEST_SECRET",
-                                         authorization_server="TEST_AUTH_SERVER",
-                                         email_address="TEST_EMAIL",
+            OAuth2UnvalidatedCredentials(
+                client_id="TEST_ID",
+                client_secret="TEST_SECRET",
+                authorization_server="TEST_AUTH_SERVER",
+                email_address="TEST_EMAIL",
             ),
         ])
 

--- a/tests/lti/services/auth_data_test.py
+++ b/tests/lti/services/auth_data_test.py
@@ -2,17 +2,14 @@
 
 from __future__ import unicode_literals
 
-import json
-import mock
 import pytest
 
 from lti.models import OAuth2AccessToken
 from lti.models import OAuth2Credentials
-from lti.services.auth_data import AuthDataService
+from lti import services
 
 
 class TestAuthData(object):
-
     """Unit tests for the AuthData class."""
 
     def test_get_lti_token(self, auth_data):
@@ -21,8 +18,8 @@ class TestAuthData(object):
         assert actual == expected
 
     def test_get_lti_token_raises_KeyError_if_oauth_consumer_key_doesnt_exist(self, auth_data):
-        with pytest.raises(KeyError) as ex:
-            actual = auth_data.get_lti_token("KEY_DOES_NOT_EXIST")
+        with pytest.raises(KeyError):
+            auth_data.get_lti_token("KEY_DOES_NOT_EXIST")
 
     def test_get_lti_token_returns_None_if_theres_no_token_for_this_client_id(self,
                                                                               auth_data,
@@ -40,13 +37,13 @@ class TestAuthData(object):
         expected = "9382~yRo ... Rlid9UXLhxfvwkWDnj"
         assert actual == expected
 
-    def test_get_lti_refresh_token_raises_KeyError_if_oauth_consumer_key_doesnt_exist(self, auth_data):
-        with pytest.raises(KeyError) as ex:
-            actual = auth_data.get_lti_refresh_token("KEY_DOES_NOT_EXIST")
+    def test_get_lti_refresh_token_raises_KeyError_if_key_doesnt_exist(self, auth_data):
+        with pytest.raises(KeyError):
+            auth_data.get_lti_refresh_token("KEY_DOES_NOT_EXIST")
 
-    def test_get_lti_refresh_token_returns_None_if_theres_no_token_for_this_client_id(self,
-                                                                                     auth_data,
-                                                                                     db_session):
+    def test_get_lti_refresh_token_returns_None_if_theres_no_token(self,
+                                                                   auth_data,
+                                                                   db_session):
         db_session.add(OAuth2Credentials(
             client_id='OTHER_CLIENT_ID',
             client_secret='OTHER_SECRET',
@@ -55,23 +52,23 @@ class TestAuthData(object):
 
         assert auth_data.get_lti_refresh_token('OTHER_CLIENT_ID') is None
 
-    def test_get_lti_secret(self,auth_data):
+    def test_get_lti_secret(self, auth_data):
         actual = auth_data.get_lti_secret("93820000000000002")
         expected = "tJzcNSZadqlHTCW6ow  ... wodX3dfeuIokkLMjrQJqw3Y2"
         assert actual == expected
 
     def test_get_lti_secret_raises_KeyError_if_oauth_consumer_key_doesnt_exist(self, auth_data):
-        with pytest.raises(KeyError) as ex:
-            actual = auth_data.get_lti_secret("KEY_DOES_NOT_EXIST")
+        with pytest.raises(KeyError):
+            auth_data.get_lti_secret("KEY_DOES_NOT_EXIST")
 
-    def test_get_canvas_server(self,auth_data):
+    def test_get_canvas_server(self, auth_data):
         actual = auth_data.get_canvas_server("93820000000000002")
         expected = "https://hypothesis.instructure.com:1000"
         assert actual == expected
 
-    def test_get_canvas_server_raises_KeyError_if_oauth_consumer_key_doesnt_exist(self, auth_data):
-        with pytest.raises(KeyError) as ex:
-            actual = auth_data.get_canvas_server("KEY_DOES_NOT_EXIST")
+    def test_get_canvas_server_raises_KeyError_if_key_doesnt_exist(self, auth_data):
+        with pytest.raises(KeyError):
+            auth_data.get_canvas_server("KEY_DOES_NOT_EXIST")
 
     def test_set_tokens(self, auth_data):
         auth_data.set_tokens("93820000000000002", "new_lti_token", "new_refresh_token")
@@ -132,9 +129,9 @@ class TestAuthData(object):
         assert auth_data.get_lti_token("93820000000000002") == (
             "9382~IAbeGEFScV  ... IIMaEdK3dXlm2d9cjozd")
 
-    def test_set_tokens_throws_assertion_error_if_oauth_consumer_key_doesnt_exist(self, auth_data):
-        with pytest.raises(AssertionError) as ex:
-            actual = auth_data.set_tokens("KEY_DOES_NOT_EXIST", "new_lti_token", "new_refresh_token")
+    def test_set_tokens_throws_assertion_error_if_key_doesnt_exist(self, auth_data):
+        with pytest.raises(AssertionError):
+            auth_data.set_tokens("KEY_DOES_NOT_EXIST", "new_lti_token", "new_refresh_token")
 
 
 @pytest.fixture
@@ -156,4 +153,4 @@ def db_session(db_session):
 
 @pytest.fixture
 def auth_data(db_session):
-    return AuthDataService(db_session)
+    return services.auth_data.AuthDataService(db_session)

--- a/tests/lti/test_routes.py
+++ b/tests/lti/test_routes.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-from lti.routes import includeme
+from lti import routes
 
 import mock
 
@@ -12,7 +12,7 @@ class TestIncludeMe(object):
     def test_it_adds_some_routes(self):
         config = mock.MagicMock()
 
-        includeme(config)
+        routes.includeme(config)
 
         expected_calls = [
             mock.call.add_route('about', '/'),

--- a/tests/lti/util/__init___test.py
+++ b/tests/lti/util/__init___test.py
@@ -12,7 +12,6 @@ from lti.util import unpack_state
 
 
 class TestPackState(object):
-
     """Unit tests for pack_state()."""
 
     def test_it_returns_a_dict_as_a_url_quoted_json_string(self):
@@ -23,7 +22,6 @@ class TestPackState(object):
 
 
 class TestUnpackState(object):
-
     """Unit tests for unpack_state()."""
 
     def test_it_returns_a_url_quoted_json_string_as_a_dict(self):
@@ -43,7 +41,6 @@ class TestUnpackState(object):
 
 
 class TestPackStateUnpackState(object):
-
     """Contract tests for how pack_state() and unpack_state() work together."""
 
     def test_unpack_state_reverses_pack_state(self):

--- a/tests/lti/util/filecache_test.py
+++ b/tests/lti/util/filecache_test.py
@@ -7,39 +7,36 @@ from lti.util import filecache
 import pytest
 
 
-@pytest.mark.usefixtures('os')
+@pytest.mark.usefixtures('os_fixture')
 class TestExistsHTML(object):
 
-    def test_it_calls_isfile_with_the_correct_path(self, os, pyramid_request):
+    def test_it_calls_isfile_with_the_correct_path(self, os_fixture, pyramid_request):
         filecache.exists_html(hash_='abc123', settings=pyramid_request.registry.settings)
 
-        os.path.isfile.assert_called_once_with('/var/lib/lti/abc123.html')
+        os_fixture.path.isfile.assert_called_once_with('/var/lib/lti/abc123.html')
 
     @pytest.mark.parametrize('isfile_return_value', [True, False])
-    def test_it_returns_what_isfile_returns(self, os, isfile_return_value, pyramid_request):
-        os.path.isfile.return_value = isfile_return_value
+    def test_it_returns_what_isfile_returns(self, os_fixture, isfile_return_value, pyramid_request):
+        os_fixture.path.isfile.return_value = isfile_return_value
 
         assert filecache.exists_html(hash_='abc123', settings=pyramid_request.registry.settings) == isfile_return_value
 
-    @pytest.fixture
-    def os(self, patch):
-        return patch('lti.util.filecache.os')
 
-
-@pytest.mark.usefixtures('os')
+@pytest.mark.usefixtures('os_fixture')
 class TestExistsPDF(object):
 
-    def test_it_calls_isfile_with_the_correct_path(self, os, pyramid_request):
+    def test_it_calls_isfile_with_the_correct_path(self, os_fixture, pyramid_request):
         filecache.exists_pdf(hash_='abc123', settings=pyramid_request.registry.settings)
 
-        os.path.isfile.assert_called_once_with('/var/lib/lti/abc123.pdf')
+        os_fixture.path.isfile.assert_called_once_with('/var/lib/lti/abc123.pdf')
 
     @pytest.mark.parametrize('isfile_return_value', [True, False])
-    def test_it_returns_what_isfile_returns(self, os, isfile_return_value, pyramid_request):
-        os.path.isfile.return_value = isfile_return_value
+    def test_it_returns_what_isfile_returns(self, os_fixture, isfile_return_value, pyramid_request):
+        os_fixture.path.isfile.return_value = isfile_return_value
 
         assert filecache.exists_pdf(hash_='abc123', settings=pyramid_request.registry.settings) == isfile_return_value
 
-    @pytest.fixture
-    def os(self, patch):
-        return patch('lti.util.filecache.os')
+
+@pytest.fixture
+def os_fixture(patch):
+    return patch('lti.util.filecache.os')

--- a/tests/lti/util/requests_test.py
+++ b/tests/lti/util/requests_test.py
@@ -122,7 +122,7 @@ class TestGetPostOrQueryParam(object):
         assert requests.get_post_or_query_param(pyramid_request, key) == 'value_from_query_string'
 
     @pytest.mark.parametrize('key', WHITELISTED_POST_PARAMS)
-    def test_an_empty_value_from_the_query_string_does_not_override_the_post_params(self, pyramid_request, key):
+    def test_an_empty_value_from_query_string_doesnt_override_post_params(self, pyramid_request, key):
         pyramid_request.query_string = urllib.urlencode({key: ''})
         pyramid_request.POST[key] = 'value_from_post_data'
 

--- a/tests/lti/views/config_test.py
+++ b/tests/lti/views/config_test.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-import urllib
+from lti.views import config
 
-import lti.views.config
 
 def test_it_returns_config_xml_object(pyramid_request):
-    actual = lti.views.config.config_xml(pyramid_request)
+    actual = config.config_xml(pyramid_request)
     assert actual['launch_url'] == 'http://example.com/lti_setup'
     assert actual['resource_selection_url'] == 'http://example.com/lti_setup'

--- a/tests/lti/views/error_test.py
+++ b/tests/lti/views/error_test.py
@@ -5,26 +5,26 @@ from __future__ import unicode_literals
 import pytest
 from pyramid import httpexceptions
 
-from lti.views.error import ErrorController
+from lti.views import error
 
 
 class TestErrorController(object):
 
     def test_httperror_sets_status_code(self, pyramid_request):
-        ErrorController(httpexceptions.HTTPNotFound(), pyramid_request).httperror()
+        error.ErrorController(httpexceptions.HTTPNotFound(), pyramid_request).httperror()
 
         assert pyramid_request.response.status_int == 404
 
     def test_httperror_returns_error_message(self, pyramid_request):
         exc = httpexceptions.HTTPNotFound("Annotation not found")
-        controller = ErrorController(exc, pyramid_request)
+        controller = error.ErrorController(exc, pyramid_request)
 
         template_data = controller.httperror()
 
         assert template_data["message"] == "Annotation not found"
 
     def test_error_sets_status_code(self, pyramid_request):
-        ErrorController(Exception(), pyramid_request).error()
+        error.ErrorController(Exception(), pyramid_request).error()
 
         assert pyramid_request.response.status_int == 500
 
@@ -32,15 +32,15 @@ class TestErrorController(object):
         pyramid_request.registry.settings["debug"] = True
 
         with pytest.raises(Exception):
-            ErrorController(Exception(), pyramid_request).error()
+            error.ErrorController(Exception(), pyramid_request).error()
 
     def test_error_reports_to_sentry(self, pyramid_request):
-        ErrorController(Exception(), pyramid_request).error()
+        error.ErrorController(Exception(), pyramid_request).error()
 
         pyramid_request.raven.captureException.assert_called_once_with()
 
     def test_error_returns_error_message(self, pyramid_request):
-        controller = ErrorController(Exception(), pyramid_request)
+        controller = error.ErrorController(Exception(), pyramid_request)
 
         template_data = controller.error()
 

--- a/tests/lti/views/export_test.py
+++ b/tests/lti/views/export_test.py
@@ -1,46 +1,42 @@
 # -*- coding: utf-8 -*-
 
-import mock
-import pytest
 import urllib
-import urlparse
 
-from pyramid.view import view_config
+import pytest
 from pyramid.httpexceptions import HTTPFound
 
-from lti import util
-import lti.views.export
+from lti.views import export
 
 
 class TestLTIExport(object):
 
     def test_it_redirects_to_the_export_facet_static_file(self, pyramid_request):
-        pyramid_request.query_string = 'args='+urllib.quote('uri=http://www.example.com&user=someone')
-        returned = lti.views.export.lti_export(pyramid_request)
+        pyramid_request.query_string = 'args=' + urllib.quote('uri=http://www.example.com&user=someone')
+        returned = export.lti_export(pyramid_request)
         assert isinstance(returned, HTTPFound)
         assert returned.location == 'http://TEST_LTI_SERVER.com/export/facet.html?facet=uri&mode=documents&search=http%3A//www.example.com&user=someone'
 
     def test_it_raises_attribute_error_when_args_is_not_set(self, pyramid_request):
-        pyramid_request.query_string = 'something_else='+urllib.quote('uri=http://www.example.com')
-        with pytest.raises(AttributeError) as ex:
-            lti.views.export.lti_export(pyramid_request)
+        pyramid_request.query_string = 'something_else=' + urllib.quote('uri=http://www.example.com')
+        with pytest.raises(AttributeError):
+            export.lti_export(pyramid_request)
 
     def test_it_raises_key_error_when_user_param_is_not_set(self, pyramid_request):
-        pyramid_request.query_string = 'args='+urllib.quote('uri=http://www.example.com')
-        with pytest.raises(KeyError) as ex:
-            lti.views.export.lti_export(pyramid_request)
+        pyramid_request.query_string = 'args=' + urllib.quote('uri=http://www.example.com')
+        with pytest.raises(KeyError):
+            export.lti_export(pyramid_request)
 
     def test_it_raises_key_error_when_user_param_is_set_without_value(self, pyramid_request):
-        pyramid_request.query_string = 'args='+urllib.quote('uri=http://www.example.com&user=')
-        with pytest.raises(KeyError) as ex:
-            lti.views.export.lti_export(pyramid_request)
+        pyramid_request.query_string = 'args=' + urllib.quote('uri=http://www.example.com&user=')
+        with pytest.raises(KeyError):
+            export.lti_export(pyramid_request)
 
     def test_it_raises_key_error_when_uri_param_is_not_set(self, pyramid_request):
-        pyramid_request.query_string = 'args='+urllib.quote('user=someone')
-        with pytest.raises(KeyError) as ex:
-            lti.views.export.lti_export(pyramid_request)
+        pyramid_request.query_string = 'args=' + urllib.quote('user=someone')
+        with pytest.raises(KeyError):
+            export.lti_export(pyramid_request)
 
     def test_it_raises_key_error_when_uri_param_is_set_without_value(self, pyramid_request):
-        pyramid_request.query_string = 'args='+urllib.quote('uri=&user=someone')
-        with pytest.raises(KeyError) as ex:
-            lti.views.export.lti_export(pyramid_request)
+        pyramid_request.query_string = 'args=' + urllib.quote('uri=&user=someone')
+        with pytest.raises(KeyError):
+            export.lti_export(pyramid_request)

--- a/tests/lti/views/oauth_test.py
+++ b/tests/lti/views/oauth_test.py
@@ -14,9 +14,8 @@ import requests
 from pyramid import httpexceptions
 
 
-# Fixtures that will automatically be used for every test in this file.
-pytestmark = pytest.mark.usefixtures(
-    'requests_fixture',  # We never want tests to really send HTTP requests.
+pytestmark = pytest.mark.usefixtures(  # pylint:disable=invalid-name
+    'requests_fixture',
     'log',
     'traceback',
     'util',
@@ -98,7 +97,6 @@ class TestMakeAuthorizationRequest(object):
 
 @pytest.mark.parametrize('method', [oauth.token_callback, oauth.refresh_callback])
 class TestTokenCallbackAndRefreshCallback(object):
-
     """Unit tests that apply to both token_callback() and refresh_callback()."""
 
     def test_it_unpacks_the_state_param(self, pyramid_request, util, method):
@@ -146,7 +144,6 @@ class TestTokenCallbackAndRefreshCallback(object):
 
     def test_it_saves_the_oauth_access_and_refresh_tokens(self,
                                                           pyramid_request,
-                                                          requests_fixture,
                                                           method,
                                                           auth_data_svc):
         """It saves the tokens from Canvas to the AuthData object."""
@@ -196,7 +193,7 @@ class TestTokenCallbackAndRefreshCallback(object):
         util.simple_response.assert_called_once_with(None)
         assert returned == util.simple_response.return_value
 
-    def test_it_logs_an_error_if_authorization_code_missing(self,
+    def test_it_logs_an_error_if_authorization_code_missing(self,  # pylint:disable=too-many-arguments
                                                             pyramid_request,
                                                             traceback,
                                                             log,
@@ -211,7 +208,7 @@ class TestTokenCallbackAndRefreshCallback(object):
 
         self.assert_that_it_logged_an_error(traceback, log, util, returned)
 
-    def test_it_logs_an_error_if_state_missing(self,
+    def test_it_logs_an_error_if_state_missing(self,  # pylint:disable=too-many-arguments
                                                pyramid_request,
                                                traceback,
                                                log,
@@ -226,7 +223,7 @@ class TestTokenCallbackAndRefreshCallback(object):
 
         self.assert_that_it_logged_an_error(traceback, log, util, returned)
 
-    def test_it_logs_an_error_if_state_isnt_valid_json(self,
+    def test_it_logs_an_error_if_state_isnt_valid_json(self,  # pylint:disable=too-many-arguments
                                                        pyramid_request,
                                                        traceback,
                                                        log,
@@ -247,7 +244,7 @@ class TestTokenCallbackAndRefreshCallback(object):
         constants.ASSIGNMENT_TYPE,
         constants.ASSIGNMENT_NAME,
         constants.ASSIGNMENT_VALUE,
-    ])
+    ])  # pylint:disable=too-many-arguments
     def test_it_logs_an_error_if_a_field_is_missing_from_state(self,
                                                                pyramid_request,
                                                                traceback,
@@ -263,7 +260,7 @@ class TestTokenCallbackAndRefreshCallback(object):
 
     # TODO: It would also log errors if AuthData raised any.
 
-    def test_it_logs_an_error_if_Canvas_login_response_isnt_json(self,
+    def test_it_logs_an_error_if_Canvas_login_response_isnt_json(self,  # pylint:disable=too-many-arguments
                                                                  pyramid_request,
                                                                  traceback,
                                                                  log,
@@ -278,7 +275,7 @@ class TestTokenCallbackAndRefreshCallback(object):
 
         self.assert_that_it_logged_an_error(traceback, log, util, returned)
 
-    def test_it_logs_an_error_if_Canvas_login_response_lacks_access_token(self,
+    def test_it_logs_an_error_if_Canvas_login_response_lacks_access_token(self,  # pylint:disable=too-many-arguments
                                                                           pyramid_request,
                                                                           traceback,
                                                                           log,
@@ -293,7 +290,6 @@ class TestTokenCallbackAndRefreshCallback(object):
 
 
 class TestTokenCallback(object):
-
     """Unit tests for token_callback() only."""
 
     def test_it_posts_an_authorization_code_request_to_canvas(self,
@@ -302,7 +298,8 @@ class TestTokenCallback(object):
         oauth.token_callback(pyramid_request)
 
         requests_fixture.post.assert_called_once_with(
-            'https://TEST_CANVAS_SERVER.com/login/oauth2/token', {
+            'https://TEST_CANVAS_SERVER.com/login/oauth2/token',
+            {
                 'code': 'TEST_OAUTH_AUTHORIZATION_CODE',
                 'grant_type': 'authorization_code',
 
@@ -311,11 +308,11 @@ class TestTokenCallback(object):
 
                 'client_id': u'TEST_OAUTH_CONSUMER_KEY',
                 'redirect_uri': 'http://TEST_LTI_SERVER.com/token_callback',
-        })
+            },
+        )
 
 
 class TestRefreshCallback(object):
-
     """Unit tests for refresh_callback() only."""
 
     def test_it_posts_a_refresh_token_request_to_canvas(self,
@@ -324,7 +321,8 @@ class TestRefreshCallback(object):
         oauth.refresh_callback(pyramid_request)
 
         requests_fixture.post.assert_called_once_with(
-            'https://TEST_CANVAS_SERVER.com/login/oauth2/token', {
+            'https://TEST_CANVAS_SERVER.com/login/oauth2/token',
+            {
                 'refresh_token': 'TEST_OAUTH_REFRESH_TOKEN',
                 'grant_type': 'refresh_token',
 
@@ -333,8 +331,8 @@ class TestRefreshCallback(object):
 
                 'client_id': u'TEST_OAUTH_CONSUMER_KEY',
                 'redirect_uri': 'http://TEST_LTI_SERVER.com/token_callback',
-        })
-
+            },
+        )
 
 
 @pytest.fixture

--- a/tests/lti/views/pdf_test.py
+++ b/tests/lti/views/pdf_test.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 import md5
 
 import pytest
-import mock
 
 from lti.views import pdf
 
@@ -25,7 +24,7 @@ class TestLTIPDF(object):
         pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -43,7 +42,7 @@ class TestLTIPDF(object):
         response = pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -60,7 +59,7 @@ class TestLTIPDF(object):
         pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -75,7 +74,7 @@ class TestLTIPDF(object):
         pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -94,7 +93,7 @@ class TestLTIPDF(object):
         pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -123,7 +122,7 @@ class TestLTIPDF(object):
         response = pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -154,10 +153,10 @@ class TestLTIPDF(object):
             'url': 'THE_URL_OF_THE_PDF_FILE',
         }
 
-        response = pdf.lti_pdf(
+        pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -180,7 +179,7 @@ class TestLTIPDF(object):
         pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -201,7 +200,7 @@ class TestLTIPDF(object):
         response = pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',
@@ -214,11 +213,12 @@ class TestLTIPDF(object):
                 name='TEST_NAME',
                 hash=expected_digest,
                 oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-                lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+                lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
                 lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
                 doc_uri='http://TEST_LTI_SERVER.com/viewer/web/' + expected_digest + '.pdf',
                 lti_server='http://TEST_LTI_SERVER.com',
-        ))
+            ),
+        )
         Response.assert_called_once_with(
             render.return_value.encode.return_value, content_type='text/html')
         assert response == Response.return_value
@@ -230,7 +230,7 @@ class TestLTIPDF(object):
         pdf.lti_pdf(
             pyramid_request,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL', 
+            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             course='TEST_COURSE',
             name='TEST_NAME',

--- a/tests/lti/views/status_test.py
+++ b/tests/lti/views/status_test.py
@@ -5,19 +5,19 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
-import lti.views.status as views
+from lti.views import status
 
 
 @pytest.mark.usefixtures('db')
 class TestStatus(object):
     def test_it_returns_okay_on_success(self, pyramid_request):
-        result = views.status(pyramid_request)
+        result = status.status(pyramid_request)
         assert result == {'status': 'okay'}
 
     def test_it_fails_when_database_unreachable(self, pyramid_request, db):
         db.execute.side_effect = Exception('explode!')
 
-        result = views.status(pyramid_request)
+        result = status.status(pyramid_request)
         assert result == {'status': 'failure',
                           'reason': 'Database connection failed'}
 

--- a/tests/lti/views/web_test.py
+++ b/tests/lti/views/web_test.py
@@ -51,7 +51,7 @@ class TestWebResponse(object):
         util.filecache.exists_html.assert_called_once_with(
             self.expected_hash(), pyramid_request.registry.settings)
 
-    def test_if_its_not_already_cached_it_gets_it_from_via(self,
+    def test_if_its_not_already_cached_it_gets_it_from_via(self,  # pylint:disable=too-many-arguments
                                                            pyramid_request,
                                                            util,
                                                            requests,
@@ -73,13 +73,12 @@ class TestWebResponse(object):
 
         requests.get.assert_called_once_with(
             'https://via.hypothes.is/TEST_ASSIGNMENT_VALUE',
-            headers={'User-Agent':'Mozilla'},
+            headers={'User-Agent': 'Mozilla'},
         )
 
-    def test_if_its_not_already_cached_it_caches_it(self,
+    def test_if_its_not_already_cached_it_caches_it(self,  # pylint:disable=too-many-arguments
                                                     pyramid_request,
                                                     util,
-                                                    requests,
                                                     open_,
                                                     auth_data_svc):
         util.filecache.exists_html.return_value = False
@@ -102,7 +101,7 @@ class TestWebResponse(object):
 
     # This is necessary to work around problems with running Via's responses
     # inside Canvas's iframe.
-    def test_it_comments_out_returns_statements_in_vias_response(self,
+    def test_it_comments_out_returns_statements_in_vias_response(self,  # pylint:disable=too-many-arguments
                                                                  pyramid_request,
                                                                  util,
                                                                  requests,
@@ -127,7 +126,7 @@ class TestWebResponse(object):
         open_.return_value.write.assert_called_once_with(
             "// return should be commented out")
 
-    def test_it_changes_src_attributes_in_vias_response(self,
+    def test_it_changes_src_attributes_in_vias_response(self,  # pylint:disable=too-many-arguments
                                                         pyramid_request,
                                                         util,
                                                         requests,
@@ -150,7 +149,7 @@ class TestWebResponse(object):
 
         open_.return_value.write.assert_called_once_with('src="https://via.hypothes.issomething"')
 
-    def test_if_the_page_is_already_cached_it_doesnt_request_it_from_via(
+    def test_if_the_page_is_already_cached_it_doesnt_request_it_from_via(  # pylint:disable=too-many-arguments
             self, pyramid_request, util, requests, open_, auth_data_svc):
         util.filecache.exists_html.return_value = True
 
@@ -168,8 +167,8 @@ class TestWebResponse(object):
 
         assert not requests.get.called
 
-    def test_if_the_page_is_already_cached_it_doesnt_write_to_the_filesystem(
-            self, pyramid_request, util, requests, open_, auth_data_svc):
+    def test_if_the_page_is_already_cached_it_doesnt_write_to_the_filesystem(  # pylint:disable=too-many-arguments
+            self, pyramid_request, util, open_, auth_data_svc):
         util.filecache.exists_html.return_value = True
 
         web.web_response(
@@ -187,7 +186,7 @@ class TestWebResponse(object):
         assert not open_.called
 
     @pytest.mark.parametrize('already_cached', [True, False])
-    def test_it_returns_the_modified_Via_page(self,
+    def test_it_returns_the_modified_Via_page(self,  # pylint:disable=too-many-arguments
                                               pyramid_request,
                                               open_,
                                               render,
@@ -229,9 +228,9 @@ class TestWebResponse(object):
 
     def expected_hash(self):
         """Return the hash for the test web page we're annotating."""
-        m = md5.new()
-        m.update('https://TEST_CANVAS_SERVER.com/TEST_COURSE_ID/TEST_ASSIGNMENT_VALUE')
-        return m.hexdigest()
+        md5_obj = md5.new()
+        md5_obj.update('https://TEST_CANVAS_SERVER.com/TEST_COURSE_ID/TEST_ASSIGNMENT_VALUE')
+        return md5_obj.hexdigest()
 
     @pytest.fixture
     def requests(self, patch):

--- a/tox.ini
+++ b/tox.ini
@@ -44,5 +44,5 @@ deps =
     -rrequirements.txt
 commands =
     -prospector
-    -prospector --profile .prospector.tests.yaml
+    -prospector tests
     -prospector --profile .prospector.app.yaml lti/app.py

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,6 @@ deps =
     pytest
     -rrequirements.txt
 commands =
-    -prospector
-    -prospector tests
-    -prospector --profile .prospector.app.yaml lti/app.py
+    prospector
+    prospector tests
+    prospector --profile .prospector.app.yaml lti/app.py

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ deps =
     prospector
     mock
     pytest
+    factory-boy
     -rrequirements.txt
 commands =
     prospector


### PR DESCRIPTION
Oops, `make lint` wasn't working for the test files, and we've ended up
committing a lot of lint violations. We'll have to get these fixed
before we can merge this.