### PR TITLE
Make `lti_credentials()` use the DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 .pydeps
 authdata.lock
 canvas-auth.json
-credentials.lock
-credentials.txt
 lti.log
 lti/static/pdfjs/viewer/web/*.html
 lti/static/pdfjs/viewer/web/*.pdf

--- a/lti/config/settings.py
+++ b/lti/config/settings.py
@@ -18,5 +18,6 @@ def env_setting(envvar_name, required=False):
         if required is True:
             raise SettingError(
                 "environment variable {envvar_name} isn't set".format(
-                    envvar_name=envvar_name)
+                    envvar_name=envvar_name,
                 )
+            )

--- a/lti/db/__init__.py
+++ b/lti/db/__init__.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import sqlalchemy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-import zope.sqlalchemy
+import zope.sqlalchemy  # pylint:disable=relative-import
 
 
 __all__ = (

--- a/lti/models/__init__.py
+++ b/lti/models/__init__.py
@@ -3,12 +3,14 @@
 from __future__ import unicode_literals
 
 from lti.models.oauth2_credentials import OAuth2Credentials
+from lti.models.oauth2_unvalidated_credentials import OAuth2UnvalidatedCredentials
 from lti.models.oauth2_access_token import OAuth2AccessToken
 
 
 __all__ = (
     'OAuth2Credentials',
     'OAuth2AccessToken',
+    'OAuth2UnvalidatedCredentials',
 )
 
 

--- a/lti/models/oauth2_credentials.py
+++ b/lti/models/oauth2_credentials.py
@@ -13,8 +13,16 @@ class OAuth2Credentials(BASE):
 
     __tablename__ = 'oauth2_credentials'
 
+    #: The OAuth 2.0 client_id.
     client_id = sa.Column(sa.UnicodeText, primary_key=True)
+
+    #: The OAuth 2.0 client_secret.
     client_secret = sa.Column(sa.UnicodeText, nullable=False)
+
+    #: The OAuth 2.0 authorization server that these credentials came from.
     authorization_server = sa.Column(sa.UnicodeText, nullable=False)
+
+    #: A list of all the access tokens that we currently have from these
+    #: credentials.
     access_tokens = relationship('OAuth2AccessToken',
                                  cascade='all, delete, delete-orphan')

--- a/lti/models/oauth2_unvalidated_credentials.py
+++ b/lti/models/oauth2_unvalidated_credentials.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import sqlalchemy as sa
+
+from lti.db import BASE
+
+
+class OAuth2UnvalidatedCredentials(BASE):
+    """
+    Unvalidated OAuth 2.0 client credentials.
+
+    This table contains unvalidated OAuth 2.0 client credentials submitted by
+    users using the ``/lti_credentials`` form. These must be manually validated
+    and then copied into the oauth2_credentials table.
+
+    """
+
+    __tablename__ = 'oauth2_unvalidated_credentials'
+
+    # In the real OAuth2Credentials table the ``client_id`` must be unique and
+    # is used as the primary key. In this unvalidated table we add a simple
+    # auto incrementing integer primary key, so that the same ``client_id`` can
+    # be submitted multiple times.
+    id = sa.Column(sa.Integer, autoincrement=True, primary_key=True)
+
+    # Users can _either_ submit a client_id and client_secret or just an
+    # access_token.
+    client_id = sa.Column(sa.UnicodeText)
+    client_secret = sa.Column(sa.UnicodeText)
+    authorization_server = sa.Column(sa.UnicodeText)
+    email_address = sa.Column(sa.UnicodeText())

--- a/lti/views/status.py
+++ b/lti/views/status.py
@@ -16,6 +16,6 @@ def status(request):
     try:
         request.db.execute('SELECT 1')
         return {'status': 'okay'}
-    except Exception as exc:
+    except Exception as exc:  # pylint:disable=broad-except
         log.exception(exc)
         return {'status': 'failure', 'reason': 'Database connection failed'}

--- a/tests/lti/models/test_oauth2_unvalidated_credentials.py
+++ b/tests/lti/models/test_oauth2_unvalidated_credentials.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from lti.models import OAuth2UnvalidatedCredentials
+
+
+class TestOAuthUnvalidated2Credentials(object):
+
+    def test_it_persists_the_fields(self, db_session):
+        db_session.add(OAuth2UnvalidatedCredentials(client_id="TEST_ID",
+                                                    client_secret="TEST_SECRET",
+                                                    authorization_server="TEST_AUTH_SERVER",
+                                                    email_address="TEST_EMAIL",
+        ))
+
+        persisted = (db_session.query(OAuth2UnvalidatedCredentials)
+                               .filter_by(client_id="TEST_ID").one())
+        assert persisted.client_id == "TEST_ID"
+        assert persisted.client_secret == "TEST_SECRET"
+        assert persisted.authorization_server == "TEST_AUTH_SERVER"
+        assert persisted.email_address == "TEST_EMAIL"
+
+    def test_you_can_add_multiple_rows_with_the_same_values(self, db_session):
+        db_session.add_all([
+            OAuth2UnvalidatedCredentials(client_id="TEST_ID",
+                                         client_secret="TEST_SECRET",
+                                         authorization_server="TEST_AUTH_SERVER",
+                                         email_address="TEST_EMAIL",
+            ),
+            OAuth2UnvalidatedCredentials(client_id="TEST_ID",
+                                         client_secret="TEST_SECRET",
+                                         authorization_server="TEST_AUTH_SERVER",
+                                         email_address="TEST_EMAIL",
+            ),
+            OAuth2UnvalidatedCredentials(client_id="TEST_ID",
+                                         client_secret="TEST_SECRET",
+                                         authorization_server="TEST_AUTH_SERVER",
+                                         email_address="TEST_EMAIL",
+            ),
+        ])
+
+        db_session.flush()


### PR DESCRIPTION
Make the `/lti_credentials` form save credentials to the DB instead of to the `credentials.txt` file.

This only supports the Path A version of the `/lti_credentials form`, but Path B hasn't actually been removed from the form yet.

A new database table, `oauth2_unvalidated_credentials`, is added to store the completely unvalidated credentials submitted via this form. These submitted credentials will have to be moved, manually, into the
`canvas-auth.json` file or in future the `oauth2_credentials` db table in order to activate the app for a particular set of credentials.