### PR TITLE
Add status healthcheck endpoint

### DIFF
--- a/lti/routes.py
+++ b/lti/routes.py
@@ -18,3 +18,6 @@ def includeme(config):
 
     config.add_route('lti_serve_pdf', '/viewer/web/{file}.pdf')
     config.add_route('catchall_pdf', '/viewer/*subpath')
+
+    # Health check
+    config.add_route('status', '/_status')

--- a/lti/views/status.py
+++ b/lti/views/status.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import logging
+
+from pyramid.view import view_config
+
+
+log = logging.getLogger(__name__)
+
+
+@view_config(route_name='status',
+             renderer='json')
+def status(request):
+    try:
+        request.db.execute('SELECT 1')
+        return {'status': 'okay'}
+    except Exception as exc:
+        log.exception(exc)
+        return {'status': 'failure', 'reason': 'Database connection failed'}

--- a/tests/lti/views/status_test.py
+++ b/tests/lti/views/status_test.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+import lti.views.status as views
+
+
+@pytest.mark.usefixtures('db')
+class TestStatus(object):
+    def test_it_returns_okay_on_success(self, pyramid_request):
+        result = views.status(pyramid_request)
+        assert result == {'status': 'okay'}
+
+    def test_it_fails_when_database_unreachable(self, pyramid_request, db):
+        db.execute.side_effect = Exception('explode!')
+
+        result = views.status(pyramid_request)
+        assert result == {'status': 'failure',
+                          'reason': 'Database connection failed'}
+
+    @pytest.fixture
+    def db(self, pyramid_request):
+        db = mock.Mock()
+        pyramid_request.db = db
+        return db


### PR DESCRIPTION
This is needed for running in our infrastructure. The endpoint itself should check the most important backend services, so currently it just checks that it is connected to PostgreSQL.