### PR TITLE
Add DB migration for oauth2_unvalidated_credentials table

### DIFF
--- a/.prospector.base.yaml
+++ b/.prospector.base.yaml
@@ -54,3 +54,5 @@ pylint:
     good-names: _,i,j,k,v,e,db,fn,fp,log,parser,id,es
 pyroma:
   run: false
+ignore-paths:
+  - lti/migrations/env.py

--- a/conf/alembic.ini
+++ b/conf/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = lti:migrations
+sqlalchemy.url: postgresql://postgres@localhost:5433/postgres
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -12,7 +12,7 @@ port: 8001
 ###
 
 [loggers]
-keys = root, lti
+keys = root, lti, alembic
 
 [handlers]
 keys = console
@@ -28,6 +28,11 @@ handlers = console
 level = DEBUG
 handlers =
 qualname = lti
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
 
 [handler_console]
 class = StreamHandler

--- a/lti/migrations/env.py
+++ b/lti/migrations/env.py
@@ -1,0 +1,80 @@
+from __future__ import with_statement
+import os
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from logging.config import fileConfig
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def get_database_url():
+    if 'DATABASE_URL' in os.environ:
+        return os.environ['DATABASE_URL']
+    return config.get_main_option("sqlalchemy.url")
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = get_database_url()
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    section = config.config_ini_section
+    config.set_section_option(section, 'sqlalchemy.url', get_database_url())
+
+    connectable = engine_from_config(
+        config.get_section(section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool)
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/lti/migrations/script.py.mako
+++ b/lti/migrations/script.py.mako
@@ -1,0 +1,23 @@
+"""
+${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/lti/migrations/versions/f013a6b67f91_add_the_oauth2_unvalidated_credentials_.py
+++ b/lti/migrations/versions/f013a6b67f91_add_the_oauth2_unvalidated_credentials_.py
@@ -1,0 +1,29 @@
+"""
+Add the oauth2_unvalidated_credentials table.
+
+Revision ID: f013a6b67f91
+Revises: None
+Create Date: 2017-08-16 16:49:03.696908
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f013a6b67f91'
+down_revision = None
+
+
+def upgrade():
+    op.create_table('oauth2_unvalidated_credentials',
+        sa.Column('id', sa.Integer, autoincrement=True, primary_key=True),
+        sa.Column('client_id', sa.UnicodeText),
+        sa.Column('client_secret', sa.UnicodeText),
+        sa.Column('authorization_server', sa.UnicodeText),
+        sa.Column('email_address', sa.UnicodeText),
+    )
+
+
+def downgrade():
+    op.drop_table('oauth2_unvalidated_credentials')

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+alembic
 requests
 pyramid
 pyramid_tm

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,16 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+alembic==0.9.5
 certifi==2017.7.27.1      # via requests
 chardet==3.0.4            # via requests
 filelock==2.0.11
 gunicorn==19.7.1
 hupper==1.0               # via pyramid
-idna==2.6                 # via requests
+idna==2.5                 # via requests
 jinja2==2.9.6             # via pyramid-jinja2
-markupsafe==1.0           # via jinja2, pyramid-jinja2
+mako==1.0.7               # via alembic
+markupsafe==1.0           # via jinja2, mako, pyramid-jinja2
 oauthlib==2.0.2           # via requests-oauthlib
 pastedeploy==1.5.2        # via plaster-pastedeploy, pyramid
 plaster-pastedeploy==0.4.1  # via pyramid
@@ -21,9 +23,12 @@ pyramid-jinja2==2.7
 pyramid-services==1.1
 pyramid-tm==2.2
 pyramid==1.9.1
+python-dateutil==2.6.1    # via alembic
+python-editor==1.0.3      # via alembic
 repoze.lru==0.6           # via pyramid
 requests-oauthlib==0.8.0
 requests==2.18.3
+six==1.10.0               # via python-dateutil
 sqlalchemy==1.1.13
 transaction==2.1.2        # via pyramid-tm, zope.sqlalchemy
 translationstring==1.3    # via pyramid


### PR DESCRIPTION
Add a database migration script for the oauth2_unvalidated_credentials
table that has already been added to the model code.

This is our first migration script, so also add migration tooling
(alembic dependency, alembic config file, env.py and script.py.mako
files for alembic) and add a section to the README about how to create a
DB migration.