### PR TITLE
Add Python error reporting to Sentry

### DIFF
--- a/conf/development.ini
+++ b/conf/development.ini
@@ -1,5 +1,6 @@
 [app:main]
 use = call:lti.app:create_app
+debug = true
 
 pyramid.reload_templates = true
 pyramid.debug_authorization = false

--- a/conf/production.ini
+++ b/conf/production.ini
@@ -1,6 +1,7 @@
 [pipeline:main]
 pipeline:
   proxy-prefix
+  raven
   lti
 
 [app:lti]
@@ -14,23 +15,26 @@ port: 8001
 [filter:proxy-prefix]
 use: egg:PasteDeploy#prefix
 
+[filter:raven]
+use: egg:raven#raven
+
 ###
 # logging configuration
 # https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
 ###
 
 [loggers]
-keys = root, lti, alembic
+keys = root, lti, alembic, sentry
 
 [handlers]
-keys = console
+keys = console, sentry
 
 [formatters]
 keys = generic
 
 [logger_root]
 level = INFO
-handlers = console
+handlers = console, sentry
 
 [logger_lti]
 level = DEBUG
@@ -42,10 +46,22 @@ level = INFO
 handlers =
 qualname = alembic
 
+[logger_sentry]
+level = WARNING
+handlers = console
+qualname = sentry.errors
+propagate = 0
+
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
 level = NOTSET
+formatter = generic
+
+[handler_sentry]
+level = WARNING
+class = raven.handlers.logging.SentryHandler
+args = ()
 formatter = generic
 
 [formatter_generic]

--- a/lti/app.py
+++ b/lti/app.py
@@ -261,6 +261,7 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.include('pyramid_services')
     config.include('pyramid_tm')
 
+    config.include('lti.sentry')
     config.include('lti.models')
     config.include('lti.db')
     config.include('lti.routes')
@@ -270,5 +271,13 @@ def create_app(global_config, **settings):  # pylint: disable=unused-argument
     config.add_view(pdf_view, route_name='catchall_pdf')
     config.add_static_view(name='export', path='lti:static/export')
 
+    config.add_static_view(name='static', path='lti:static')
+
+    config.registry.settings['jinja2.filters'] = {
+        'static_path': 'pyramid_jinja2.filters:static_path_filter',
+        'static_url': 'pyramid_jinja2.filters:static_url_filter',
+    }
+
     config.scan()
+
     return config.make_wsgi_app()

--- a/lti/sentry.py
+++ b/lti/sentry.py
@@ -1,0 +1,37 @@
+"""Report exceptions to Sentry."""
+
+import os
+
+import raven
+from raven.utils.wsgi import get_environ
+
+
+def get_raven_client(request):
+    """Return the Raven client for reporting crashes to Sentry."""
+    client = request.registry["raven.client"]
+    client.http_context({
+        'url': request.url,
+        'method': request.method,
+        'data': request.body,
+        'query_string': request.query_string,
+        'cookies': dict(request.cookies),
+        'headers': dict(request.headers),
+        'env': dict(get_environ(request.environ)),
+    })
+    client.user_context({
+        'ip_address': request.client_addr,
+    })
+    request.add_finished_callback(lambda request: client.context.clear())
+    return client
+
+
+def includeme(config):
+    environment = os.environ.get('ENV', 'dev')
+    config.registry["raven.client"] = raven.Client(
+        environment=environment,
+        processors=[
+            'raven.processors.SanitizePasswordsProcessor',
+            'raven.processors.RemovePostDataProcessor',
+        ],
+    )
+    config.add_request_method(get_raven_client, name="raven", reify=True)

--- a/lti/static/images/sad-annotation.svg
+++ b/lti/static/images/sad-annotation.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="83.25"
+   height="77"
+   viewBox="0 0 83.250001 77"
+   version="1.1"
+   id="svg2"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="sad-annotation.svg">
+  <metadata
+     id="metadata22">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Slice 1</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1136"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="14.511061"
+     inkscape:cx="40.492557"
+     inkscape:cy="26.433356"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <!-- Generator: Sketch 3.2.2 (9983) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title4">Slice 1</title>
+  <desc
+     id="desc6">Created with Sketch.</desc>
+  <defs
+     id="defs8" />
+  <g
+     id="g4190"
+     transform="matrix(2.7499752,0,0,2.7499752,-94.498774,87.999238)">
+    <path
+       id="Active-Browser-Action-2"
+       d="m 40.775628,-31.99996 c -3.383384,0 -6.17429,2.743483 -6.233678,6.128566 l -0.177487,10.116796 c -0.05938,3.384714 2.636624,6.170658 6.021232,6.220446 0,0 3.294847,0.05556 3.422692,0.03896 3.054071,0.501576 4.553784,5.509558 5.626192,5.495351 1.17924,-0.01427 2.467031,-5.54251 5.757035,-5.626193 2.038215,0.04573 3.033319,0.02027 3.033319,0.02027 3.383074,-0.01119 6.17373,-2.76375 6.233117,-6.148833 l 0.177488,-10.116796 c 0.05938,-3.384713 -2.636179,-6.128566 -6.018641,-6.128566 l -17.841269,0 0,0 z m 1.527685,3.009359 c -2.538406,0 -4.633292,2.054603 -4.679175,4.595603 l -0.124636,6.902321 c -0.04583,2.538081 1.974395,4.627187 4.511683,4.664669 0,0 2.847145,0.04737 2.948104,0.03426 2.411799,0.396104 3.929323,3.549019 4.484978,3.560239 0.555655,0.01122 1.906237,-3.597481 4.504351,-3.663567 1.609577,0.03612 4.168132,0.01369 4.168132,0.01369 1.692566,-0.0076 3.089438,-1.385812 3.120006,-3.078638 l 0.152275,-8.432973 c 0.04583,-2.538084 -1.974083,-4.595605 -4.513209,-4.595605 l -14.572509,0 0,0 z"
+       inkscape:connector-curvature="0"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+    <ellipse
+       ry="2.093467"
+       rx="1.5701002"
+       cy="-23.364407"
+       cx="44.200912"
+       id="Oval-1"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+    <path
+       id="Oval-2"
+       d="m 54.668247,-21.270942 c 0.867142,0 1.5701,-0.937277 1.5701,-2.093467 0,-1.15619 -0.702958,-2.093467 -1.5701,-2.093467 -0.867143,0 -1.5701,0.937277 -1.5701,2.093467 0,1.15619 0.702957,2.093467 1.5701,2.093467 l 0,0 z"
+       inkscape:connector-curvature="0"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+    <path
+       id="path18"
+       d="m 49.434579,-16.853951 c 0.841137,0.03915 1.314276,0.227372 1.654528,0.330742 0.337431,0.174845 0.630819,0.445402 0.835266,0.799515 0.226995,0.393166 0.728087,0.528826 1.119221,0.303005 0.391134,-0.225822 0.524196,-0.72761 0.297201,-1.120776 -0.812015,-1.406451 -2.381656,-1.981801 -3.906216,-1.981801 -1.57713,0 -3.0942,0.57535 -3.906215,1.981801 -0.226995,0.393166 -0.09393,0.894954 0.297201,1.120776 0.391134,0.225821 0.892226,0.09016 1.11922,-0.303005 0.204448,-0.354113 0.497835,-0.62467 0.835267,-0.799515 0,0 0.865962,-0.291589 1.654527,-0.330742 l 0,0 z"
+       inkscape:connector-curvature="0"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1" />
+  </g>
+</svg>

--- a/lti/static/styles/lti.css
+++ b/lti/static/styles/lti.css
@@ -1,0 +1,19 @@
+body {
+  color: #7a7a7a;
+  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 14px;
+}
+
+p {
+  margin: 0;
+}
+
+/* Vertically and horizontally center a block such as a <div>. */
+.center {
+  display: block;
+  left: 50%;
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/lti/templates/base.html.jinja2
+++ b/lti/templates/base.html.jinja2
@@ -1,0 +1,16 @@
+<!doctype html>
+  <html lang=en>
+  <head>
+    <meta charset=utf-8>
+    <title>{{ title|safe }}</title>
+    <link rel="stylesheet"
+          type="text/css"
+          href="{{'lti:static/styles/lti.css'|static_path}}">
+  </head>
+  <body>
+    <div class="center">
+      {% block content %}{% endblock %}
+    </div>
+  </body>
+  {% block scripts %}{% endblock %}
+</html>

--- a/lti/templates/error.html.jinja2
+++ b/lti/templates/error.html.jinja2
@@ -1,0 +1,10 @@
+{% extends 'templates/base.html.jinja2' %}
+
+{% set title = message %}
+
+{% block content %}
+  <img src="{{ 'lti:static/images/sad-annotation.svg'|static_path }}">
+  <p>
+    {{ message|safe }}
+  </p>
+{% endblock %}

--- a/lti/views/config.py
+++ b/lti/views/config.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import unicode_literals
+
 from pyramid.view import view_config
 
 

--- a/lti/views/error.py
+++ b/lti/views/error.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from pyramid import httpexceptions
+from pyramid import i18n
+from pyramid.view import view_config
+from pyramid.view import view_defaults
+from pyramid.settings import asbool
+
+
+_ = i18n.TranslationStringFactory(__package__)
+
+
+@view_defaults(renderer='lti:templates/error.html.jinja2')
+class ErrorController(object):
+
+    def __init__(self, exc, request):
+        self.exc = exc
+        self.request = request
+
+    @view_config(context=httpexceptions.HTTPError)
+    @view_config(context=httpexceptions.HTTPServerError)
+    def httperror(self):
+        self.request.response.status_int = self.exc.status_int
+        # If code raises an HTTPError or HTTPServerError we assume this was
+        # deliberately raised and:
+        # 1. Show the user an error page including specific error message
+        # 2. _Do not_ report the error to Sentry
+        return {'message': str(self.exc)}
+
+    @view_config(context=Exception)
+    def error(self):
+        # In debug mode re-raise exceptions so that they get printed in the
+        # terminal.
+        if asbool(self.request.registry.settings.get('debug')):
+            raise self.exc
+
+        self.request.response.status_int = 500
+
+        # If code raises a non-HTTPException exception we assume it was a bug
+        # and:
+        # 1. Show the user a generic error page
+        # 2. Report the details of the error to Sentry
+        self.request.raven.captureException()
+        return {'message': _("Sorry, but something went wrong. "
+                             "The issue has been reported and we'll try to "
+                             "fix it.")}

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ gunicorn
 sqlalchemy
 psycopg2
 zope.sqlalchemy
+raven

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 alembic==0.9.5
 certifi==2017.7.27.1      # via requests
 chardet==3.0.4            # via requests
+contextlib2==0.5.5        # via raven
 filelock==2.0.11
 gunicorn==19.7.1
 hupper==1.0               # via pyramid
@@ -26,6 +27,7 @@ pyramid-tm==2.2
 pyramid==1.9.1
 python-dateutil==2.6.1    # via alembic
 python-editor==1.0.3      # via alembic
+raven==6.1.0
 repoze.lru==0.6           # via pyramid
 requests-oauthlib==0.8.0
 requests==2.18.3

--- a/tests/lti/conftest.py
+++ b/tests/lti/conftest.py
@@ -101,6 +101,8 @@ def pyramid_request():
         constants.LIS_RESULT_SOURCEDID: 'TEST_LIS_RESULT_SOURCEDID',
     })
 
+    pyramid_request.raven = mock.MagicMock(spec_set=['captureException'])
+
     return pyramid_request
 
 

--- a/tests/lti/views/error_test.py
+++ b/tests/lti/views/error_test.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+from pyramid import httpexceptions
+
+from lti.views.error import ErrorController
+
+
+class TestErrorController(object):
+
+    def test_httperror_sets_status_code(self, pyramid_request):
+        ErrorController(httpexceptions.HTTPNotFound(), pyramid_request).httperror()
+
+        assert pyramid_request.response.status_int == 404
+
+    def test_httperror_returns_error_message(self, pyramid_request):
+        exc = httpexceptions.HTTPNotFound("Annotation not found")
+        controller = ErrorController(exc, pyramid_request)
+
+        template_data = controller.httperror()
+
+        assert template_data["message"] == "Annotation not found"
+
+    def test_error_sets_status_code(self, pyramid_request):
+        ErrorController(Exception(), pyramid_request).error()
+
+        assert pyramid_request.response.status_int == 500
+
+    def test_error_raises_in_debug_mode(self, pyramid_request):
+        pyramid_request.registry.settings["debug"] = True
+
+        with pytest.raises(Exception):
+            ErrorController(Exception(), pyramid_request).error()
+
+    def test_error_reports_to_sentry(self, pyramid_request):
+        ErrorController(Exception(), pyramid_request).error()
+
+        pyramid_request.raven.captureException.assert_called_once_with()
+
+    def test_error_returns_error_message(self, pyramid_request):
+        controller = ErrorController(Exception(), pyramid_request)
+
+        template_data = controller.error()
+
+        assert template_data["message"].startswith("Sorry, but")


### PR DESCRIPTION
This adds Sentry reporting of Python errors only, JavaScript can be added later.

Requires the `SENTRY_DSN` env var to be set in production.