### PR TITLE
Use Via and the client's new JSON-RPC-over-postMessage feature for PDF assignments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,9 @@ You will need:
 * Python
 * Virtualenv
 * Docker
+* You'll need [h](https://github.com/hypothesis/h),
+  [client](https://github.com/hypothesis/client) and
+  [via](https://github.com/hypothesis/via) development environments running
 * ...
 
 To get the Canvas app running in a dev environment:
@@ -122,6 +125,8 @@ To get the Canvas app running in a dev environment:
    ```bash
    export LTI_SERVER="http://localhost:8001"
    export LTI_CREDENTIALS_URL="http://localhost:8001/lti_credentials"
+   export CLIENT_ORIGIN="http://localhost:5000"
+   export VIA_URL="http://localhost:9080"
    ```
 
 1. Run the development server. First create and activate a Python virtual

--- a/lti/config/__init__.py
+++ b/lti/config/__init__.py
@@ -25,10 +25,23 @@ def configure(settings=None):
                                            required=True),
         'lti_files_path': env_setting('LTI_FILES_PATH',
                                       default='./lti/static/pdfjs/viewer/web'),
+        # The origin that this app should use when sending postMessage()
+        # requests to the Hypothesis client (e.g. "https://hypothes.is" in prod
+        # or "http://localhost:5000" in dev).
+        'client_origin': env_setting('CLIENT_ORIGIN', required=True),
+
+        # The URL of the https://github.com/hypothesis/via instance to
+        # integrate with.
+        'via_url': env_setting('VIA_URL', required=True),
     }
+
     database_url = env_setting('DATABASE_URL')
     if database_url:
         env_settings['sqlalchemy.url'] = database_url
+
+    # Make sure that via_url doesn't end with a /.
+    if env_settings['via_url'].endswith('/'):
+        env_settings['via_url'] = env_settings['via_url'][:-1]
 
     settings.update(env_settings)
 

--- a/lti/static/export/facet.html
+++ b/lti/static/export/facet.html
@@ -55,7 +55,29 @@ var user = gup('user', args);
 
 document.getElementById('title').innerHTML = 'Annotations by ' + user;
 
-query += '&' + facet + '=' + search;
+function getParameterByName(name, url) {
+    if (!url) url = window.location.href;
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+}
+
+try {
+  var uris = JSON.parse(getParameterByName("search"));
+  query += uris.reduce(function(acc, curr) { return acc + "&uri=" + encodeURIComponent(curr); }, "")
+} catch (e) {
+  if (e.name == "SyntaxError") {
+    // Looks like the "search" parameter wasn't JSON.
+    // This must be a legacy assignment submission where the search param was
+    // just a single URI, not a JSON array of URIs.
+    query += '&' + facet + '=' + search;
+  } else {
+    throw e;
+  }
+}
 
 if ( mode == 'documents' )
   query = query + '&_separate_replies=true';

--- a/lti/templates/includes/submission_form.html.jinja2
+++ b/lti/templates/includes/submission_form.html.jinja2
@@ -1,13 +1,39 @@
 {# Template for assignment submission form #}
 <script>
+function receiveMessage(event) {
+  if (event.origin !== "{{ client_origin }}") {
+    return;
+  }
+
+  if (!event.data.result) {
+    return;
+  }
+
+  var uris = encodeURIComponent(JSON.stringify(event.data.result));
+
+  var h_user = document.querySelector('#h_username').value.trim();
+  var submit_url = '/lti_submit?oauth_consumer_key={{ oauth_consumer_key }}&lis_outcome_service_url={{ lis_outcome_service_url }}&lis_result_sourcedid={{ lis_result_sourcedid }}';
+  var export_url = '{{ lti_server }}/lti_export?args=' + encodeURIComponent('uris=' + uris + '&user=' + h_user);
+  submit_url += '&export_url=' + encodeURIComponent(export_url);
+  location.href = submit_url;
+}
+
+window.addEventListener("message", receiveMessage, false);
+
 function make_submit_url() {
-    var h_user = document.querySelector('#h_username').value.trim();
-    var submit_url = '/lti_submit?oauth_consumer_key={{ oauth_consumer_key }}&lis_outcome_service_url={{ lis_outcome_service_url }}&lis_result_sourcedid={{ lis_result_sourcedid }}';
-    var export_url = '{{ lti_server }}/lti_export?args=' + encodeURIComponent('uri={{ doc_uri }}&user=' + h_user);
-    console.log(export_url);
-    console.log(encodeURIComponent(export_url));
-    submit_url += '&export_url=' + encodeURIComponent(export_url);
-    return submit_url;
+    // We can't find out which iframe is the client's iframe (same-origin
+    // policy prevents this) but we can iterate over _every_ iframe in the
+    // "viewer" iframe and call postMessage() on each of them. The
+    // client_origin param ensures that the message will only actually be
+    // delivered to the Hypothesis client's iframe.
+    var viewer = window.frames["viewer"];
+    var i;
+    for (i=0; i<viewer.frames.length; i+=1) {
+      viewer.frames[i].postMessage({
+        'method': 'searchUris',
+        'id': 0,
+      }, "{{ client_origin }}");
+    }
 }
 function clear_input() {
   var h_user = document.querySelector('#h_username');
@@ -29,5 +55,5 @@ function show_stream_link() {
 When you're done annotating:
 <div>1. Enter your Hypothesis username: <input onfocus="javascript:clear_input()" onchange="javascript:show_stream_link()" id="h_username"></div>
 <div>2. Check the name:  <span style="display:none" id="check_username"> <a target="stream" title="check your name" href=""> </a></span>
-<div>3. Click <input type="button" value="Submit Assignment" onclick="javascript:location.href=make_submit_url()"></div>
+<div>3. Click <input type="button" value="Submit Assignment" onclick="javascript:make_submit_url()"></div>
 </p>

--- a/lti/templates/pdf_assignment.html.jinja2
+++ b/lti/templates/pdf_assignment.html.jinja2
@@ -13,6 +13,6 @@
     {% if lis_result_sourcedid %}
       {% include 'lti:templates/includes/submission_form.html.jinja2' %}
     {% endif %}
-    <iframe width="100%%" height="1000px" src="/viewer/web/viewer.html?file={{ hash }}.pdf"></iframe>
+    <iframe width="100%%" height="1000px" name="viewer" src="{{ via_url }}/{{ pdf_url }}"></iframe>
   </body>
 </html>

--- a/lti/views/export.py
+++ b/lti/views/export.py
@@ -21,6 +21,17 @@ def lti_export(request):
     args = util.requests.get_query_param(request, 'args')  # because canvas swallows & in the submitted pox, we pass an opaque construct and unpack here
     parsed_args = urlparse.parse_qs(args)
     user = parsed_args['user'][0]
-    uri = parsed_args['uri'][0]
-    export_url = '%s/export/facet.html?facet=uri&mode=documents&search=%s&user=%s' % (request.registry.settings['lti_server'], urllib.quote(uri), user)
+
+    if 'uri' in parsed_args:
+        uri = parsed_args['uri'][0]
+        export_url = '%s/export/facet.html?facet=uri&mode=documents&search=%s&user=%s' % (
+            request.registry.settings['lti_server'],
+            urllib.quote(uri),
+            user)
+    else:
+        uris = parsed_args['uris'][0]
+        export_url = '%s/export/facet.html?facet=uri&mode=documents&search=%s&user=%s' % (
+            request.registry.settings['lti_server'],
+            urllib.quote(uris),
+            user)
     return HTTPFound(location=export_url)

--- a/lti/views/pdf.py
+++ b/lti/views/pdf.py
@@ -3,10 +3,8 @@
 from __future__ import unicode_literals
 
 import urllib
-import shutil
 import json
 import logging
-import hashlib
 
 import requests
 from pyramid.renderers import render
@@ -43,56 +41,27 @@ def lti_pdf(request, oauth_consumer_key, lis_outcome_service_url,
         return util.simple_response("We don't have the Consumer Key %s in our database yet." % oauth_consumer_key)
     canvas_server = auth_data_svc.get_canvas_server(oauth_consumer_key)
     url = '%s/api/v1/courses/%s/files/%s' % (canvas_server, course, file_id)
-    md5_obj = hashlib.md5()
-    md5_obj.update('%s/%s/%s' % (canvas_server, course, file_id))
-    digest = md5_obj.hexdigest()
-    path = '%s/%s.pdf' % (request.registry.settings['lti_files_path'], digest)
-    log.debug("Path for PDF file in cache is: %s", path)
-    if util.filecache.exists_pdf(digest, request.registry.settings) is False:
-        log.debug("%s is not already cached", digest)
-        sess = requests.Session()
-        log.debug("Getting %s metadata from %s", digest, url)
-        response = sess.get(url=url, headers={'Authorization': 'Bearer %s' % lti_token})
-        if response.status_code == 401:
-            return oauth.make_authorization_request(
-                request, 'pdf:' + urllib.quote(json.dumps(post_data)),
-                refresh=True)
-        if response.status_code == 200:
-            j = response.json()
-            url = j['url']
-            log.debug("Downloading %s from %s", digest, url)
-            urllib.urlretrieve(url, digest)
-            log.debug("Hash of downloaded file is: %s", hash_of_file_contents(digest))
-            log.debug("Moving %s to %s", digest, path)
-            shutil.move(digest, path)
-    else:
-        log.debug("%s is already cached", digest)
 
-    log.debug("Hash of cached file is: %s", hash_of_file_contents(path))
-
-    fingerprint = util.pdf.get_fingerprint(digest, request.registry.settings)
-    if fingerprint is None:
-        pdf_uri = '%s/viewer/web/%s.pdf' % (request.registry.settings['lti_server'], digest)
-    else:
-        pdf_uri = 'urn:x-pdf:%s' % fingerprint
+    sess = requests.Session()
+    response = sess.get(url=url, headers={'Authorization': 'Bearer %s' % lti_token})
+    if response.status_code == 401:
+        return oauth.make_authorization_request(
+            request, 'pdf:' + urllib.quote(json.dumps(post_data)),
+            refresh=True)
+    if response.status_code == 200:
+        j = response.json()
+        url = j['url']
 
     return Response(
         render('lti:templates/pdf_assignment.html.jinja2', dict(
                name=name,
-               hash=digest,
+               pdf_url=url,
                oauth_consumer_key=oauth_consumer_key,
                lis_outcome_service_url=lis_outcome_service_url,
                lis_result_sourcedid=lis_result_sourcedid,
-               doc_uri=pdf_uri,
                lti_server=request.registry.settings['lti_server'],
+               client_origin=request.registry.settings['client_origin'],
+               via_url=request.registry.settings['via_url'],
                )).encode('utf-8'),
         content_type='text/html',
     )
-
-
-def hash_of_file_contents(fname):
-    hash_md5 = hashlib.md5()
-    with open(fname, "rb") as file_:
-        for chunk in iter(lambda: file_.read(4096), b""):
-            hash_md5.update(chunk)
-    return hash_md5.hexdigest()

--- a/tests/lti/config/__init___test.py
+++ b/tests/lti/config/__init___test.py
@@ -27,6 +27,8 @@ class TestConfigure(object):
                 'LTI_SERVER': 'the_lti_server_setting',
                 'LTI_CREDENTIALS_URL':  'the_lti_credentials_url_setting',
                 'DATABASE_URL': 'the_database_url',
+                'CLIENT_ORIGIN': 'the_client_origin',
+                'VIA_URL': 'the_via_url',
             }[envvar_name]
 
         env_setting.side_effect = env_setting_side_effect
@@ -36,6 +38,8 @@ class TestConfigure(object):
         assert config.registry.settings['lti_server'] == 'the_lti_server_setting'
         assert config.registry.settings['lti_credentials_url'] == 'the_lti_credentials_url_setting'
         assert config.registry.settings['sqlalchemy.url'] == 'the_database_url'
+        assert config.registry.settings['client_origin'] == 'the_client_origin'
+        assert config.registry.settings['via_url'] == 'the_via_url'
 
     @pytest.fixture
     def env_setting(self, patch):

--- a/tests/lti/conftest.py
+++ b/tests/lti/conftest.py
@@ -120,6 +120,8 @@ def pyramid_config(pyramid_request):
         'lti_server': 'http://TEST_LTI_SERVER.com',
         'lti_files_path': '/var/lib/lti',
         'sqlalchemy.url': TEST_DATABASE_URL,
+        'client_origin': 'http://TEST_H_SERVER.is',
+        'via_url': 'http://TEST_VIA_SERVER.is',
     }
 
     with testing.testConfig(request=pyramid_request, settings=settings) as config:

--- a/tests/lti/views/export_test.py
+++ b/tests/lti/views/export_test.py
@@ -11,10 +11,18 @@ from lti.views import export
 class TestLTIExport(object):
 
     def test_it_redirects_to_the_export_facet_static_file(self, pyramid_request):
+        # This is for legacy support of single-URI submissions.
         pyramid_request.query_string = 'args=' + urllib.quote('uri=http://www.example.com&user=someone')
         returned = export.lti_export(pyramid_request)
         assert isinstance(returned, HTTPFound)
         assert returned.location == 'http://TEST_LTI_SERVER.com/export/facet.html?facet=uri&mode=documents&search=http%3A//www.example.com&user=someone'
+
+    def test_it_redirects_to_the_export_facet_static_file_with_multiple_uris(self, pyramid_request):
+        # This is for the new multi-URI submissions.
+        pyramid_request.query_string = 'args=' + urllib.quote('uris=THE_URIS&user=someone')
+        returned = export.lti_export(pyramid_request)
+        assert isinstance(returned, HTTPFound)
+        assert returned.location == 'http://TEST_LTI_SERVER.com/export/facet.html?facet=uri&mode=documents&search=THE_URIS&user=someone'
 
     def test_it_raises_attribute_error_when_args_is_not_set(self, pyramid_request):
         pyramid_request.query_string = 'something_else=' + urllib.quote('uri=http://www.example.com')


### PR DESCRIPTION
Change PDF assignments to work by passing the PDF file (Canvas Files API
download URL) through `https://via.hypothes.is`, instead of by downloading
the PDF file to this app's local filesystem and re-serving it from a URL
of this app.

`view/pdf.py`:

- This is the Python code for the PDF assignment view.

- No longer download PDF files from Canvas to the app's local
  filesystem, which means this view also no longer needs to calculate
  hashes of PDF file contents, or to get fingerprints from PDF files,
  or to check whether the file has already been downloaded, etc.

- This view does still need to talk to the Canvas Files API each time
  this view is requested to get the download URL of the PDF file.
  These Canvas download URLs are temporary, so we have to ask the Canvas
  API for a new one every time.

- Pass the PDF file download URL to `pdf_assignment.html.jinja2` (below).

`pdf_assignment.html.jinja2`:

- Render an `<iframe>` to `https://via.hypothes.is` instead of to this
  LTI app's built in PDF.js viewer.

`submission_form.html.jinja2`:

- When the submit button is clicked send a JSON-RPC request to the
  Hypothesis client over `postMessage`, asking for the URIs of the
  document the client is annotating.

- Receive the client's JSON-RPC response and submit the assignment using
  these (possibly multiple) URIs instead of just the one URI as before.

`export.py`:

- This is the server-side part of the Speed Grader view.
  Receive the multiple URIs submitted to Canvas by
  `submission_form.html.jinja2` (above) and pass them to `facet.html`
  (below) in the `search` query param.

`facet.html`:

- This is the Speed Grader view, which is implemented in HTML and
  JavaScript. The Python app now passes it multiple URIs in the query
  string, instead of juse one. So `facet.html` now parses the multiple
  URIs out of the `search` URL param and constructs an h API search
  query for annotations of all of these URIs instead of just searching
  for one URI.

## See also

* [Client PR that adds the cross-origin RPC feature to the client](https://github.com/hypothesis/client/pull/550)
* [h PR that enables the cross-origin RPC feature in the client](https://github.com/hypothesis/h/pull/4670)