### PR TITLE
Remove caching of Via responses

### DIFF
--- a/lti/templates/html_assignment.html.jinja2
+++ b/lti/templates/html_assignment.html.jinja2
@@ -13,6 +13,6 @@
     {% if lis_result_sourcedid %}
       {% include 'lti:templates/includes/submission_form.html.jinja2' %}
     {% endif %}
-    <iframe width="100%%" height="1000px" src="{{ path }}"></iframe>
+    <iframe width="100%%" height="1000px" src="{{ url }}"></iframe>
   </body>
 </html>

--- a/lti/templates/html_assignment.html.jinja2
+++ b/lti/templates/html_assignment.html.jinja2
@@ -13,6 +13,6 @@
     {% if lis_result_sourcedid %}
       {% include 'lti:templates/includes/submission_form.html.jinja2' %}
     {% endif %}
-    <iframe width="100%%" height="1000px" src="{{ url }}"></iframe>
+    <iframe width="100%%" height="1000px" name="viewer" src="{{ url }}"></iframe>
   </body>
 </html>

--- a/lti/views/setup.py
+++ b/lti/views/setup.py
@@ -97,7 +97,7 @@ def lti_setup(request):
                                 lis_outcome_service_url=lis_outcome_service_url,
                                 lis_result_sourcedid=lis_result_sourcedid,
                                 name=assignment_name,
-                                value=assignment_value)
+                                url=assignment_value)
 
     return_url = util.requests.get_post_or_query_param(request, constants.EXT_CONTENT_RETURN_URL)
     if return_url is None:  # this is an oauth redirect so get what we sent ourselves

--- a/lti/views/setup.py
+++ b/lti/views/setup.py
@@ -91,9 +91,7 @@ def lti_setup(request):
 
     if assignment_type == 'web':
         return web.web_response(request,
-                                auth_data_svc,
                                 oauth_consumer_key=oauth_consumer_key,
-                                course=course,
                                 lis_outcome_service_url=lis_outcome_service_url,
                                 lis_result_sourcedid=lis_result_sourcedid,
                                 name=assignment_name,

--- a/lti/views/web.py
+++ b/lti/views/web.py
@@ -13,9 +13,9 @@ from lti import util
 
 
 # pylint: disable=too-many-arguments, too-many-locals
-def web_response(request, auth_data_svc, oauth_consumer_key=None, course=None,
-                 lis_outcome_service_url=None, lis_result_sourcedid=None,
-                 name=None, url=None, open_=None):
+def web_response(request, auth_data_svc, oauth_consumer_key, course,
+                 lis_outcome_service_url, lis_result_sourcedid, name, url,
+                 open_=None):
     """
     Return an annotatable proxied copy of the given URL.
 

--- a/lti/views/web.py
+++ b/lti/views/web.py
@@ -65,7 +65,6 @@ def web_response(request, auth_data_svc, oauth_consumer_key=None, course=None,
         oauth_consumer_key=oauth_consumer_key,
         lis_outcome_service_url=lis_outcome_service_url,
         lis_result_sourcedid=lis_result_sourcedid,
-        doc_uri=url,
         lti_server=request.registry.settings['lti_server'],
     ))
     return Response(html.encode('utf-8'), content_type='text/html')

--- a/lti/views/web.py
+++ b/lti/views/web.py
@@ -15,11 +15,11 @@ from lti import util
 # pylint: disable=too-many-arguments, too-many-locals
 def web_response(request, auth_data_svc, oauth_consumer_key=None, course=None,
                  lis_outcome_service_url=None, lis_result_sourcedid=None,
-                 name=None, value=None, open_=None):
+                 name=None, url=None, open_=None):
     """
     Return an annotatable proxied copy of the given URL.
 
-    The `value` argument is the URL to return. Pass this URL to Via and return
+    The `url` argument is the URL to return. Pass this URL to Via and return
     Via's response (after some modification) as an HTML response.
 
     The HTTP request to Via is done synchronously in this function.
@@ -31,8 +31,6 @@ def web_response(request, auth_data_svc, oauth_consumer_key=None, course=None,
 
     """
     open_ = open_ or open  # Test seam.
-
-    url = value
 
     canvas_server = auth_data_svc.get_canvas_server(oauth_consumer_key)
 

--- a/lti/views/web.py
+++ b/lti/views/web.py
@@ -30,5 +30,6 @@ def web_response(request, oauth_consumer_key, lis_outcome_service_url,
         lis_outcome_service_url=lis_outcome_service_url,
         lis_result_sourcedid=lis_result_sourcedid,
         lti_server=request.registry.settings['lti_server'],
+        client_origin=request.registry.settings['client_origin'],
     ))
     return Response(html.encode('utf-8'), content_type='text/html')

--- a/lti/views/web.py
+++ b/lti/views/web.py
@@ -2,20 +2,13 @@
 
 from __future__ import unicode_literals
 
-import md5
-import os.path
-
-import requests
 from pyramid.response import Response
 from pyramid.renderers import render
 
-from lti import util
-
 
 # pylint: disable=too-many-arguments, too-many-locals
-def web_response(request, auth_data_svc, oauth_consumer_key, course,
-                 lis_outcome_service_url, lis_result_sourcedid, name, url,
-                 open_=None):
+def web_response(request, oauth_consumer_key, lis_outcome_service_url,
+                 lis_result_sourcedid, name, url):
     """
     Return an annotatable proxied copy of the given URL.
 
@@ -30,36 +23,9 @@ def web_response(request, auth_data_svc, oauth_consumer_key, course,
     again.
 
     """
-    open_ = open_ or open  # Test seam.
-
-    canvas_server = auth_data_svc.get_canvas_server(oauth_consumer_key)
-
-    # Create a fingerprint of the URL of the page to be annotated.
-    # The fingerprint is Canvas instance- and course-specific.
-    md5_obj = md5.new()
-    md5_obj.update('%s/%s/%s' % (canvas_server, course, url))
-    digest = md5_obj.hexdigest()
-
-    if util.filecache.exists_html(digest, request.registry.settings) is False:
-        # This URL isn't cached yet (for this Canvas instance and course),
-        # so request the page from Via and cache it.
-        via_response = requests.get('https://via.hypothes.is/%s' % url,
-                                    headers={'User-Agent': 'Mozilla'})
-
-        # Work around https://github.com/hypothesis/via/issues/76
-        text = via_response.text.replace('return;', '// return')
-
-        # ?
-        text = text.replace("""src="/im_""", 'src="https://via.hypothes.is')
-
-        cached_file = open_('%s/%s.html' % (request.registry.settings['lti_files_path'], digest), 'wb')
-        cached_file.write(text.encode('utf-8'))
-        cached_file.close()
-
     html = render('lti:templates/html_assignment.html.jinja2', dict(
         name=name,
-        path=request.static_path(os.path.join(
-            request.registry.settings['lti_files_path'], digest + '.html')),
+        url=request.registry.settings['via_url'] + '/' + url,
         oauth_consumer_key=oauth_consumer_key,
         lis_outcome_service_url=lis_outcome_service_url,
         lis_result_sourcedid=lis_result_sourcedid,

--- a/tests/lti/views/setup_test.py
+++ b/tests/lti/views/setup_test.py
@@ -73,7 +73,7 @@ class TestLTISetupWhenWeDontHaveAnAccessToken(SharedLTISetupTests):
         setup.lti_setup(pyramid_request)
 
         pack_state.assert_called_once_with({
-            constants.ASSIGNMENT_VALUE: 'TEST_ASSIGNMENT_VALUE',
+            constants.ASSIGNMENT_VALUE: 'TEST_ASSIGNMENT_URL',
             constants.ASSIGNMENT_NAME: 'TEST_ASSIGNMENT_NAME',
             constants.ASSIGNMENT_TYPE: 'TEST_ASSIGNMENT_TYPE',
             constants.CUSTOM_CANVAS_ASSIGNMENT_ID: 'TEST_ASSIGNMENT_ID',
@@ -194,7 +194,7 @@ class TestLTISetupWhenWeHaveAValidAccessToken(SharedLTISetupTests):
         # FIXME: We shouldn't have to actually encode a query string in tests
         # like this.
         pyramid_request.query_string = urllib.urlencode({
-            constants.ASSIGNMENT_VALUE: 'TEST_ASSIGNMENT_VALUE',
+            constants.ASSIGNMENT_VALUE: 'TEST_ASSIGNMENT_URL',
             constants.ASSIGNMENT_NAME: 'TEST_ASSIGNMENT_NAME',
             constants.ASSIGNMENT_TYPE: 'web',
         })
@@ -209,7 +209,7 @@ class TestLTISetupWhenWeHaveAValidAccessToken(SharedLTISetupTests):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
         )
         assert returned == web.web_response.return_value
 
@@ -219,7 +219,7 @@ class TestLTISetupWhenWeHaveAValidAccessToken(SharedLTISetupTests):
         # FIXME: We shouldn't have to actually encode a query string in tests
         # like this.
         pyramid_request.query_string = urllib.urlencode({
-            constants.ASSIGNMENT_VALUE: 'TEST_ASSIGNMENT_VALUE',
+            constants.ASSIGNMENT_VALUE: 'TEST_ASSIGNMENT_URL',
             constants.ASSIGNMENT_NAME: 'TEST_ASSIGNMENT_NAME',
             # No assignment_type param here.
         })
@@ -420,7 +420,7 @@ def pyramid_request(pyramid_request):
     # FIXME: It looks like these params _also_ appear in the request body, so
     # our code should just get them from the request body like the others.
     pyramid_request.query_string = urllib.urlencode({
-        constants.ASSIGNMENT_VALUE: 'TEST_ASSIGNMENT_VALUE',
+        constants.ASSIGNMENT_VALUE: 'TEST_ASSIGNMENT_URL',
         constants.ASSIGNMENT_NAME: 'TEST_ASSIGNMENT_NAME',
         constants.ASSIGNMENT_TYPE: 'TEST_ASSIGNMENT_TYPE',
     })

--- a/tests/lti/views/setup_test.py
+++ b/tests/lti/views/setup_test.py
@@ -189,8 +189,7 @@ class TestLTISetupWhenWeHaveAValidAccessToken(SharedLTISetupTests):
     # FIXME: This should be a "when it's a web assignment" class.
     def test_it_returns_web_response_if_its_a_web_assignment(self,
                                                              pyramid_request,
-                                                             web,
-                                                             auth_data_svc):
+                                                             web):
         # FIXME: We shouldn't have to actually encode a query string in tests
         # like this.
         pyramid_request.query_string = urllib.urlencode({
@@ -203,9 +202,7 @@ class TestLTISetupWhenWeHaveAValidAccessToken(SharedLTISetupTests):
 
         web.web_response.assert_called_once_with(
             pyramid_request,
-            auth_data_svc,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',

--- a/tests/lti/views/web_test.py
+++ b/tests/lti/views/web_test.py
@@ -25,7 +25,7 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
@@ -44,7 +44,7 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
@@ -67,12 +67,12 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
         requests.get.assert_called_once_with(
-            'https://via.hypothes.is/TEST_ASSIGNMENT_VALUE',
+            'https://via.hypothes.is/TEST_ASSIGNMENT_URL',
             headers={'User-Agent': 'Mozilla'},
         )
 
@@ -91,7 +91,7 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
@@ -119,7 +119,7 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
@@ -143,7 +143,7 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
@@ -161,7 +161,7 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
@@ -179,7 +179,7 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
@@ -209,7 +209,7 @@ class TestWebResponse(object):
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
-            value='TEST_ASSIGNMENT_VALUE',
+            url='TEST_ASSIGNMENT_URL',
             open_=open_,
         )
 
@@ -228,7 +228,7 @@ class TestWebResponse(object):
     def expected_hash(self):
         """Return the hash for the test web page we're annotating."""
         md5_obj = md5.new()
-        md5_obj.update('https://TEST_CANVAS_SERVER.com/TEST_COURSE_ID/TEST_ASSIGNMENT_VALUE')
+        md5_obj.update('https://TEST_CANVAS_SERVER.com/TEST_COURSE_ID/TEST_ASSIGNMENT_URL')
         return md5_obj.hexdigest()
 
     @pytest.fixture

--- a/tests/lti/views/web_test.py
+++ b/tests/lti/views/web_test.py
@@ -32,6 +32,7 @@ class TestWebResponse(object):
             'lis_outcome_service_url': 'TEST_LIS_OUTCOME_SERVICE_URL',
             'lis_result_sourcedid': 'TEST_LIS_RESULT_SOURCEDID',
             'lti_server': 'http://TEST_LTI_SERVER.com',
+            'client_origin': 'http://TEST_H_SERVER.is',
         })
         Response.assert_called_once_with('THE_RENDERED_HTML_PAGE',
                                          content_type='text/html')

--- a/tests/lti/views/web_test.py
+++ b/tests/lti/views/web_test.py
@@ -219,7 +219,6 @@ class TestWebResponse(object):
             'oauth_consumer_key': 'TEST_OAUTH_CONSUMER_KEY',
             'lis_outcome_service_url': 'TEST_LIS_OUTCOME_SERVICE_URL',
             'lis_result_sourcedid': 'TEST_LIS_RESULT_SOURCEDID',
-            'doc_uri': 'TEST_ASSIGNMENT_VALUE',
             'lti_server': 'http://TEST_LTI_SERVER.com',
         })
         Response.assert_called_once_with('THE_RENDERED_HTML_PAGE',

--- a/tests/lti/views/web_test.py
+++ b/tests/lti/views/web_test.py
@@ -2,220 +2,32 @@
 
 from __future__ import unicode_literals
 
-import md5
-
 from lti.views import web
 
 import pytest
-import mock
 
 
-@pytest.mark.usefixtures('requests', 'render', 'util', 'Response')
+@pytest.mark.usefixtures('render', 'Response')
 class TestWebResponse(object):
 
-    def test_it_gets_the_canvas_servers_url_from_the_database(self,
-                                                              pyramid_request,
-                                                              open_,
-                                                              auth_data_svc):
-        web.web_response(
-            request=pyramid_request,
-            auth_data_svc=auth_data_svc,
-            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
-            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
-            name='TEST_ASSIGNMENT_NAME',
-            url='TEST_ASSIGNMENT_URL',
-            open_=open_,
-        )
-
-        auth_data_svc.get_canvas_server.assert_called_once_with('TEST_OAUTH_CONSUMER_KEY')
-
-    def test_it_checks_whether_the_file_is_already_cached(self,
-                                                          pyramid_request,
-                                                          open_,
-                                                          util,
-                                                          auth_data_svc):
-        web.web_response(
-            request=pyramid_request,
-            auth_data_svc=auth_data_svc,
-            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
-            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
-            name='TEST_ASSIGNMENT_NAME',
-            url='TEST_ASSIGNMENT_URL',
-            open_=open_,
-        )
-
-        util.filecache.exists_html.assert_called_once_with(
-            self.expected_hash(), pyramid_request.registry.settings)
-
-    def test_if_its_not_already_cached_it_gets_it_from_via(self,  # pylint:disable=too-many-arguments
-                                                           pyramid_request,
-                                                           util,
-                                                           requests,
-                                                           open_,
-                                                           auth_data_svc):
-        util.filecache.exists_html.return_value = False
-
-        web.web_response(
-            request=pyramid_request,
-            auth_data_svc=auth_data_svc,
-            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
-            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
-            name='TEST_ASSIGNMENT_NAME',
-            url='TEST_ASSIGNMENT_URL',
-            open_=open_,
-        )
-
-        requests.get.assert_called_once_with(
-            'https://via.hypothes.is/TEST_ASSIGNMENT_URL',
-            headers={'User-Agent': 'Mozilla'},
-        )
-
-    def test_if_its_not_already_cached_it_caches_it(self,  # pylint:disable=too-many-arguments
-                                                    pyramid_request,
-                                                    util,
-                                                    open_,
-                                                    auth_data_svc):
-        util.filecache.exists_html.return_value = False
-
-        web.web_response(
-            request=pyramid_request,
-            auth_data_svc=auth_data_svc,
-            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
-            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
-            name='TEST_ASSIGNMENT_NAME',
-            url='TEST_ASSIGNMENT_URL',
-            open_=open_,
-        )
-
-        open_.assert_called_once_with('/var/lib/lti/' + self.expected_hash() + '.html', 'wb')
-        open_.return_value.write.assert_called_once_with("The text of the web page")
-        open_.return_value.close.assert_called_once_with()
-
-    # This is necessary to work around problems with running Via's responses
-    # inside Canvas's iframe.
-    def test_it_comments_out_returns_statements_in_vias_response(self,  # pylint:disable=too-many-arguments
-                                                                 pyramid_request,
-                                                                 util,
-                                                                 requests,
-                                                                 open_,
-                                                                 auth_data_svc):
-        util.filecache.exists_html.return_value = False
-        requests.get.return_value.text = (
-            "return; should be commented out")
-
-        web.web_response(
-            request=pyramid_request,
-            auth_data_svc=auth_data_svc,
-            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
-            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
-            name='TEST_ASSIGNMENT_NAME',
-            url='TEST_ASSIGNMENT_URL',
-            open_=open_,
-        )
-
-        open_.return_value.write.assert_called_once_with(
-            "// return should be commented out")
-
-    def test_it_changes_src_attributes_in_vias_response(self,  # pylint:disable=too-many-arguments
-                                                        pyramid_request,
-                                                        util,
-                                                        requests,
-                                                        open_,
-                                                        auth_data_svc):
-        util.filecache.exists_html.return_value = False
-        requests.get.return_value.text = ('src="/im_something"')
-
-        web.web_response(
-            request=pyramid_request,
-            auth_data_svc=auth_data_svc,
-            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
-            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
-            name='TEST_ASSIGNMENT_NAME',
-            url='TEST_ASSIGNMENT_URL',
-            open_=open_,
-        )
-
-        open_.return_value.write.assert_called_once_with('src="https://via.hypothes.issomething"')
-
-    def test_if_the_page_is_already_cached_it_doesnt_request_it_from_via(  # pylint:disable=too-many-arguments
-            self, pyramid_request, util, requests, open_, auth_data_svc):
-        util.filecache.exists_html.return_value = True
-
-        web.web_response(
-            request=pyramid_request,
-            auth_data_svc=auth_data_svc,
-            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
-            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
-            name='TEST_ASSIGNMENT_NAME',
-            url='TEST_ASSIGNMENT_URL',
-            open_=open_,
-        )
-
-        assert not requests.get.called
-
-    def test_if_the_page_is_already_cached_it_doesnt_write_to_the_filesystem(  # pylint:disable=too-many-arguments
-            self, pyramid_request, util, open_, auth_data_svc):
-        util.filecache.exists_html.return_value = True
-
-        web.web_response(
-            request=pyramid_request,
-            auth_data_svc=auth_data_svc,
-            oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
-            lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
-            lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
-            name='TEST_ASSIGNMENT_NAME',
-            url='TEST_ASSIGNMENT_URL',
-            open_=open_,
-        )
-
-        assert not open_.called
-
-    @pytest.mark.parametrize('already_cached', [True, False])
-    def test_it_returns_the_modified_Via_page(self,  # pylint:disable=too-many-arguments
+    def test_it_returns_the_expected_response(self,  # pylint:disable=too-many-arguments
                                               pyramid_request,
-                                              open_,
                                               render,
-                                              Response,
-                                              already_cached,
-                                              util,
-                                              auth_data_svc):
-        # It returns the modified Via page as an HTML response,
-        # regardless of whether the page was retrieved from the cache or has
-        # just been fetched from Via now.
-        util.filecache.exists_html.return_value = already_cached
-
+                                              Response):
         render.return_value = 'THE_RENDERED_HTML_PAGE'
 
         response = web.web_response(
             request=pyramid_request,
-            auth_data_svc=auth_data_svc,
             oauth_consumer_key='TEST_OAUTH_CONSUMER_KEY',
-            course='TEST_COURSE_ID',
             lis_outcome_service_url='TEST_LIS_OUTCOME_SERVICE_URL',
             lis_result_sourcedid='TEST_LIS_RESULT_SOURCEDID',
             name='TEST_ASSIGNMENT_NAME',
             url='TEST_ASSIGNMENT_URL',
-            open_=open_,
         )
 
         render.assert_called_once_with('lti:templates/html_assignment.html.jinja2', {
             'name': 'TEST_ASSIGNMENT_NAME',
-            'path': '/cache/' + self.expected_hash() + '.html',
+            'url': 'http://TEST_VIA_SERVER.is/TEST_ASSIGNMENT_URL',
             'oauth_consumer_key': 'TEST_OAUTH_CONSUMER_KEY',
             'lis_outcome_service_url': 'TEST_LIS_OUTCOME_SERVICE_URL',
             'lis_result_sourcedid': 'TEST_LIS_RESULT_SOURCEDID',
@@ -225,33 +37,9 @@ class TestWebResponse(object):
                                          content_type='text/html')
         assert response == Response.return_value
 
-    def expected_hash(self):
-        """Return the hash for the test web page we're annotating."""
-        md5_obj = md5.new()
-        md5_obj.update('https://TEST_CANVAS_SERVER.com/TEST_COURSE_ID/TEST_ASSIGNMENT_URL')
-        return md5_obj.hexdigest()
-
-    @pytest.fixture
-    def requests(self, patch):
-        requests = patch('lti.views.web.requests')
-
-        # The responses that web_response() gets when it calls Via.
-        requests.get.return_value.status_code = 200
-        requests.get.return_value.text = "The text of the web page"
-
-        return requests
-
-    @pytest.fixture
-    def open_(self):
-        return mock.MagicMock()
-
     @pytest.fixture
     def render(self, patch):
         return patch('lti.views.web.render')
-
-    @pytest.fixture
-    def util(self, patch):
-        return patch('lti.views.web.util')
 
     @pytest.fixture
     def Response(self, patch):


### PR DESCRIPTION
Remove all code to do with downloading and caching and re-serving Via
responses, and modifying those responses. Instead for web assignments
just inject a Via iframe and let Via proxy the web page and inject
Hypothesis, just as we already do for PDF assignments.

Requires hypothesis/via#113